### PR TITLE
Use system time for interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ A JSON histogramming configuration has the following parameters:
 
 * "data_brokers" (string array): the addresses of the Kafka brokers
 * "data_topics" (string array): the topics to listen for event data on
-* "start" (seconds since epoch in ns): only histogram data after this time [optional]
-* "stop" (seconds since epoch in ns): only histogram data up to this time [optional]
+* "start" (seconds since epoch in ms): only histogram data after this UTC time [optional]
+* "stop" (seconds since epoch in ms): only histogram data up to this UTC time [optional]
 * "interval" (seconds): only histogram for this interval [optional]
 * "histograms" (array of dicts): the histograms to create, contains the following:
     * "type" (string): the histogram type (hist1d or hist2d)
@@ -120,8 +120,8 @@ For example:
   "cmd": "config",
   "data_brokers": ["localhost:9092"],
   "data_topics": ["TEST_events"],
-  "start": 1558676657538999557,
-  "stop":  1558677657538999557,
+  "start": 1564727596867,
+  "stop":  1564727668779,
   "histograms": [
     {
       "type": "hist1d",

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ optional arguments:
   -o, --one-shot-plot   runs the program until it gets some data, plot it and
                         then exit. Used for testing
   -s, --simulation-mode
-                        runs the program in simulation mode. 1-D histograms
-                        only.
+                        runs the program in simulation mode.
 
   -l LOG_LEVEL, --log-level LOG_LEVEL
                         sets the logging level: debug=1, info=2, warning=3,
@@ -154,6 +153,11 @@ To restarting the histograms counting from zero, send the restart command:
 ```
 This will start all the histograms counting from zero but will not change any other
 settings, such as bin edges etc.
+
+### Simulation mode
+When in simulation mode just-bin-it will try to provide simulated data matching
+the requested configuration. For example: if the config specifies a 2-D
+histogram then the simulated data will be 2-D.
 
 ### One-shot plot
 When the `one-shot-plot` option is specified then the program with collect a

--- a/client/client.py
+++ b/client/client.py
@@ -50,8 +50,8 @@ def main(brokers, topic):
     while len(buffs) == 0:
         buffs = hist_source.get_new_data()
 
-    # Only care about the most recent histogram.
-    hist = buffs[-1]
+    # Only care about the most recent histogram and don't care about kafka timestamps
+    _, _, hist = buffs[-1]
 
     plot_histogram(hist)
 

--- a/endpoints/kafka_consumer.py
+++ b/endpoints/kafka_consumer.py
@@ -73,10 +73,6 @@ class Consumer:
             # Either the topic is empty or the requested time is greater than
             # highest message time in the topic.
             return None
-        #     raise Exception(
-        #         "Unable to locate start time in topic - start time too high or the topic empty?"
-        #     )
-        # offset =
         return answer[self.topic_partitions[0]].offset
 
     def seek_by_offset(self, offset):

--- a/endpoints/kafka_consumer.py
+++ b/endpoints/kafka_consumer.py
@@ -45,7 +45,7 @@ class Consumer:
         data = self.consumer.poll(5)
         for tp in self.topic_partitions:
             logging.debug(
-                f"{tp.topic} - current position: {self.consumer.position(tp)}"
+                "%s - current position: %s", tp.topic, self.consumer.position(tp)
             )
         return data
 

--- a/endpoints/kafka_consumer.py
+++ b/endpoints/kafka_consumer.py
@@ -57,27 +57,27 @@ class Consumer:
         """
         return self._get_new_messages()
 
-    def seek_by_time(self, start_time: int):
+    def offset_for_time(self, start_time: int):
         """
-        Move the offset to the position corresponding to the supplied time.
+        Find the offset to the position corresponding to the supplied time.
 
         :param start_time: Time to seek in microseconds.
         :return: The offset number.
         """
-        return self._seek_by_time(start_time)
+        return self._offset_for_time(start_time)
 
-    def _seek_by_time(self, start_time):
+    def _offset_for_time(self, start_time):
         # TODO: what about more than one topic?
         answer = self.consumer.offsets_for_times({self.topic_partitions[0]: start_time})
         if answer[self.topic_partitions[0]] is None:
             # Either the topic is empty or the requested time is greater than
             # highest message time in the topic.
-            raise Exception(
-                "Unable to locate start time in topic - start time too high or the topic empty?"
-            )
-        offset = answer[self.topic_partitions[0]].offset
-        self.consumer.seek(self.topic_partitions[0], offset)
-        return offset
+            return None
+        #     raise Exception(
+        #         "Unable to locate start time in topic - start time too high or the topic empty?"
+        #     )
+        # offset =
+        return answer[self.topic_partitions[0]].offset
 
     def seek_by_offset(self, offset):
         """

--- a/endpoints/kafka_producer.py
+++ b/endpoints/kafka_producer.py
@@ -17,7 +17,9 @@ class Producer:
         :param brokers: The brokers to connect to.
         """
         try:
-            self.producer = KafkaProducer(bootstrap_servers=brokers)
+            self.producer = KafkaProducer(
+                bootstrap_servers=brokers, max_request_size=100_000_000
+            )
         except KafkaError as error:
             raise Exception(error)
 

--- a/endpoints/kafka_tools.py
+++ b/endpoints/kafka_tools.py
@@ -14,7 +14,7 @@ def are_kafka_settings_valid(brokers, topics):
     try:
         consumer = KafkaConsumer(bootstrap_servers=brokers)
     except KafkaError as error:
-        logging.error(f"Could not connect to Kafka brokers: {error}")
+        logging.error("Could not connect to Kafka brokers: %s", error)
         return False
 
     result = True
@@ -22,10 +22,10 @@ def are_kafka_settings_valid(brokers, topics):
         existing_topics = consumer.topics()
         for tp in topics:
             if tp not in existing_topics:
-                logging.error(f"Could not find topic: {tp}")
+                logging.error("Could not find topic: %s", tp)
                 result = False
     except KafkaError as error:
-        logging.error(f"Could not get topics from Kafka: {error}")
+        logging.error("Could not get topics from Kafka: %s", error)
         return False
 
     return result

--- a/endpoints/sources.py
+++ b/endpoints/sources.py
@@ -142,4 +142,4 @@ class SimulatedEventSource:
             "det_ids": dets,
             "source": "simulator",
         }
-        return [data]
+        return [(int(time.time() * 1000), 0, data)]

--- a/endpoints/sources.py
+++ b/endpoints/sources.py
@@ -39,7 +39,7 @@ class BaseSource:
                 try:
                     data.append((i.timestamp, i.offset, self._process_record(i.value)))
                 except SourceException as error:
-                    logging.warning(f"SourceException: {error}")  # pragma: no mutate
+                    logging.warning("SourceException: %s", error)  # pragma: no mutate
 
         return data
 

--- a/endpoints/sources.py
+++ b/endpoints/sources.py
@@ -143,3 +143,15 @@ class SimulatedEventSource:
             "source": "simulator",
         }
         return [(int(time.time() * 1000), 0, data)]
+
+    def seek_to_time(self, requested_time: int):
+        """
+        Does nothing.
+
+        This command needs to be available so that the simulated source can be used as
+        a like for like replacement for a real source
+
+        :param requested_time: ignored
+        :return:
+        """
+        return 0

--- a/histograms/det_histogram.py
+++ b/histograms/det_histogram.py
@@ -1,29 +1,29 @@
 import numpy as np
+from fast_histogram import histogram1d
 import logging
 
 
-class Histogram2d:
-    """Two dimensional histogram for time-of-flight."""
+class DetHistogram:
+    """Two dimensional histogram for detectors."""
 
-    def __init__(
-        self, topic, num_bins, tof_range, det_range, source=None, identifier=""
-    ):
+    def __init__(self, topic, tof_range, det_range, width, source=None, identifier=""):
         """
         Constructor.
 
         :param topic: The name of the Kafka topic to publish to.
-        :param num_bins: The number of bins to divide the data up into.
         :param tof_range: The range of time-of-flights to histogram over.
         :param source: The data source to histogram.
         :param det_range: The range of sequential detectors to histogram over.
+        :param width: How many detectors in a row.
         :param identifier: An optional identifier for the histogram.
         """
         self._histogram = None
         self.x_edges = None
-        self.y_edges = None
         self.tof_range = tof_range
         self.det_range = det_range
-        self.num_bins = num_bins
+        # The number of bins is the number of detectors.
+        self.num_bins = det_range[1] - det_range[0] + 1
+        self.width = width
         self.topic = topic
         self.last_pulse_time = 0
         self.identifier = identifier
@@ -35,9 +35,21 @@ class Histogram2d:
         """
         Create a zeroed histogram with the correct shape.
         """
-        self._histogram, self.x_edges, self.y_edges = np.histogram2d(
-            [], [], range=(self.tof_range, self.det_range), bins=self.num_bins
-        )
+        # If the number of detectors is not a multiple of the width, then cannot make a
+        # rectangle
+        if self.num_bins % self.width != 0:
+            raise Exception("Detector range and width are incompatible")
+
+        self.x_edges = np.histogram_bin_edges([], self.num_bins, self.det_range)
+        self._histogram = histogram1d([], range=self.det_range, bins=self.num_bins)
+
+    @property
+    def data(self):
+        return self._histogram
+
+    @property
+    def shape(self):
+        return self._histogram.shape
 
     def add_data(self, pulse_time, tof, det_ids, source=""):
         """
@@ -54,17 +66,9 @@ class Histogram2d:
 
         self.last_pulse_time = pulse_time
 
-        self._histogram += np.histogram2d(
-            tof, det_ids, range=(self.tof_range, self.det_range), bins=self.num_bins
-        )[0]
-
-    @property
-    def data(self):
-        return self._histogram
-
-    @property
-    def shape(self):
-        return self._histogram.shape
+        self._histogram += histogram1d(
+            det_ids, range=self.det_range, bins=self.num_bins
+        )
 
     def clear_data(self):
         """

--- a/histograms/det_histogram.py
+++ b/histograms/det_histogram.py
@@ -1,12 +1,13 @@
 import numpy as np
-from fast_histogram import histogram1d
 import logging
 
 
 class DetHistogram:
     """Two dimensional histogram for detectors."""
 
-    def __init__(self, topic, tof_range, det_range, width, source=None, identifier=""):
+    def __init__(
+        self, topic, tof_range, det_range, width, height, source=None, identifier=""
+    ):
         """
         Constructor.
 
@@ -15,6 +16,7 @@ class DetHistogram:
         :param source: The data source to histogram.
         :param det_range: The range of sequential detectors to histogram over.
         :param width: How many detectors in a row.
+        :param height:
         :param identifier: An optional identifier for the histogram.
         """
         self._histogram = None
@@ -24,7 +26,7 @@ class DetHistogram:
         # The number of bins is the number of detectors.
         self.num_bins = det_range[1] - det_range[0] + 1
         self.width = width
-        self.height = self.num_bins // self.width
+        self.height = height
         self.topic = topic
         self.last_pulse_time = 0
         self.identifier = identifier
@@ -36,13 +38,6 @@ class DetHistogram:
         """
         Create a zeroed histogram with the correct shape.
         """
-        # If the number of detectors is not a multiple of the width, then cannot make a
-        # rectangle
-        if self.num_bins % self.width != 0:
-            raise Exception("Detector range and width are incompatible")
-
-        # self.x_edges = np.histogram_bin_edges([], self.num_bins, self.det_range)
-        # self._histogram = histogram1d([], range=self.det_range, bins=self.num_bins)
         self._histogram, self.x_edges, self.y_edges = np.histogram2d(
             [],
             [],
@@ -73,11 +68,23 @@ class DetHistogram:
 
         self.last_pulse_time = pulse_time
 
-        hist_1 = histogram1d(det_ids, range=self.det_range, bins=self.num_bins)
+        dets_x = []
+        dets_y = []
 
-        self._histogram += hist_1.view().reshape(
-            (self.width, self.num_bins // self.width)
-        )
+        for d in det_ids:
+            if d == 0 or d < self.det_range[0] or d > self.det_range[1]:
+                continue
+            x = (d - 1) % self.width
+            y = ((d - 1) // self.width) % self.height
+            dets_x.append(x)
+            dets_y.append(y)
+
+        self._histogram += np.histogram2d(
+            dets_x,
+            dets_y,
+            range=((0, self.width), (0, self.height)),
+            bins=(self.width, self.height),
+        )[0]
 
     def clear_data(self):
         """

--- a/histograms/histogram1d.py
+++ b/histograms/histogram1d.py
@@ -12,6 +12,7 @@ class Histogram1d:
         topic,
         num_bins,
         tof_range,
+        det_range=None,
         source=None,
         preprocessor=None,
         roi=None,
@@ -26,6 +27,7 @@ class Histogram1d:
         :param topic: The name of the Kafka topic to publish to.
         :param num_bins: The number of bins to divide the time-of-flight up into.
         :param tof_range: The time-of-flight range to histogram over.
+        :param det_range: The detector range to include data from.
         :param source: The data source to histogram.
         :param preprocessor: The function to apply to the data before adding.
         :param roi: The function for checking data is within the region of interest.
@@ -34,6 +36,7 @@ class Histogram1d:
         self._histogram = None
         self.x_edges = None
         self.tof_range = tof_range
+        self.det_range = det_range
         self.num_bins = num_bins
         self.source = source
         self.topic = topic
@@ -73,6 +76,13 @@ class Histogram1d:
             mask = self._get_mask(pulse_time, tofs, det_ids)
             if mask:
                 tofs = ma.array(tofs, mask=mask).compressed()
+
+        if self.det_range:
+            tofs = [
+                t
+                for t, d in zip(tofs, det_ids)
+                if self.det_range[0] <= d <= self.det_range[1]
+            ]
 
         self._histogram += histogram1d(tofs, range=self.tof_range, bins=self.num_bins)
 

--- a/histograms/histogram2d.py
+++ b/histograms/histogram2d.py
@@ -14,8 +14,8 @@ class Histogram2d:
         :param topic: The name of the Kafka topic to publish to.
         :param num_bins: The number of bins to divide the data up into.
         :param tof_range: The range of time-of-flights to histogram over.
-        :param source: The data source to histogram.
         :param det_range: The range of sequential detectors to histogram over.
+        :param source: The data source to histogram.
         :param identifier: An optional identifier for the histogram.
         """
         self._histogram = None

--- a/histograms/histogram_factory.py
+++ b/histograms/histogram_factory.py
@@ -31,21 +31,27 @@ class HistogramFactory:
             identifier = h["id"] if "id" in h else ""
             width = h["width"] if "width" in h else 0
 
-            if hist_type == "hist1d":
-                HistogramFactory.check_1d_info(num_bins, tof_range)
-                hist = Histogram1d(topic, num_bins, tof_range, source)
-            elif hist_type == "hist2d":
-                hist = Histogram2d(topic, num_bins, tof_range, det_range, source)
-            elif hist_type == "sehist1d":
-                hist = SingleEventHistogram1d(topic, num_bins, tof_range, source)
-            elif hist_type == "dethist":
-                hist = DetHistogram(topic, tof_range, det_range, width, source)
-            else:
-                # TODO: skip it, throw or what?
+            try:
+                if hist_type == "hist1d":
+                    HistogramFactory.check_1d_info(num_bins, tof_range)
+                    hist = Histogram1d(topic, num_bins, tof_range, source)
+                elif hist_type == "hist2d":
+                    # TODO: check 2d info
+                    hist = Histogram2d(topic, num_bins, tof_range, det_range, source)
+                elif hist_type == "sehist1d":
+                    hist = SingleEventHistogram1d(topic, num_bins, tof_range, source)
+                elif hist_type == "dethist":
+                    # TODO: check 2d info
+                    hist = DetHistogram(topic, tof_range, det_range, width, source)
+                else:
+                    # Log but do nothing
+                    logging.warning(
+                        "Unrecognised histogram type: %s", hist_type
+                    )  # pragma: no mutate
+            except Exception as error:
                 logging.warning(
-                    "Unrecognised histogram type: %s", hist_type
+                    "Could not create histogram: %s", error
                 )  # pragma: no mutate
-                pass
 
             if hist is not None:
                 hist.identifier = identifier

--- a/histograms/histogram_factory.py
+++ b/histograms/histogram_factory.py
@@ -35,7 +35,7 @@ class HistogramFactory:
             try:
                 if hist_type == "hist1d":
                     HistogramFactory.check_1d_info(num_bins, tof_range)
-                    hist = Histogram1d(topic, num_bins, tof_range, source)
+                    hist = Histogram1d(topic, num_bins, tof_range, det_range, source)
                 elif hist_type == "hist2d":
                     # TODO: check 2d info
                     hist = Histogram2d(topic, num_bins, tof_range, det_range, source)

--- a/histograms/histogram_factory.py
+++ b/histograms/histogram_factory.py
@@ -2,6 +2,7 @@ import logging
 from histograms.histogram1d import Histogram1d
 from histograms.histogram2d import Histogram2d
 from histograms.single_event_histogram1d import SingleEventHistogram1d
+from histograms.det_histogram import DetHistogram
 
 
 class HistogramFactory:
@@ -28,6 +29,7 @@ class HistogramFactory:
             det_range = tuple(h["det_range"]) if "det_range" in h else None
             source = h["source"] if "source" in h else None
             identifier = h["id"] if "id" in h else ""
+            width = h["width"] if "width" in h else 0
 
             if hist_type == "hist1d":
                 HistogramFactory.check_1d_info(num_bins, tof_range)
@@ -36,6 +38,8 @@ class HistogramFactory:
                 hist = Histogram2d(topic, num_bins, tof_range, det_range, source)
             elif hist_type == "sehist1d":
                 hist = SingleEventHistogram1d(topic, num_bins, tof_range, source)
+            elif hist_type == "dethist":
+                hist = DetHistogram(topic, tof_range, det_range, width, source)
             else:
                 # TODO: skip it, throw or what?
                 logging.warning(

--- a/histograms/histogram_factory.py
+++ b/histograms/histogram_factory.py
@@ -29,7 +29,8 @@ class HistogramFactory:
             det_range = tuple(h["det_range"]) if "det_range" in h else None
             source = h["source"] if "source" in h else None
             identifier = h["id"] if "id" in h else ""
-            width = h["width"] if "width" in h else 0
+            width = h["width"] if "width" in h else 512
+            height = h["height"] if "height" in h else 512
 
             try:
                 if hist_type == "hist1d":
@@ -42,7 +43,9 @@ class HistogramFactory:
                     hist = SingleEventHistogram1d(topic, num_bins, tof_range, source)
                 elif hist_type == "dethist":
                     # TODO: check 2d info
-                    hist = DetHistogram(topic, tof_range, det_range, width, source)
+                    hist = DetHistogram(
+                        topic, tof_range, det_range, width, height, source
+                    )
                 else:
                     # Log but do nothing
                     logging.warning(

--- a/histograms/histogram_factory.py
+++ b/histograms/histogram_factory.py
@@ -39,7 +39,7 @@ class HistogramFactory:
             else:
                 # TODO: skip it, throw or what?
                 logging.warning(
-                    f"Unrecognised histogram type: {hist_type}"
+                    "Unrecognised histogram type: %s", hist_type
                 )  # pragma: no mutate
                 pass
 

--- a/histograms/histogrammer.py
+++ b/histograms/histogrammer.py
@@ -6,7 +6,7 @@ from endpoints.histogram_sink import HistogramSink
 HISTOGRAM_STATES = {
     "COUNTING": "COUNTING",
     "FINISHED": "FINISHED",
-    "NOT_STARTED": "NOT_STARTED",
+    "INITIALISED": "INITIALISED",
 }
 
 
@@ -115,7 +115,7 @@ class Histogrammer:
         elif self._started:
             info["state"] = HISTOGRAM_STATES["COUNTING"]
         else:
-            info["state"] = HISTOGRAM_STATES["NOT_STARTED"]
+            info["state"] = HISTOGRAM_STATES["INITIALISED"]
 
         return info
 

--- a/histograms/histogrammer.py
+++ b/histograms/histogrammer.py
@@ -1,4 +1,5 @@
 import json
+import time
 from histograms.histogram_factory import HistogramFactory
 from endpoints.histogram_sink import HistogramSink
 
@@ -9,28 +10,41 @@ HISTOGRAM_STATES = {
 }
 
 
-def create_histogrammer(producer, configuration):
+def create_histogrammer(producer, configuration, current_time=None):
     """
     Creates a fully configured histogrammer.
 
     :param producer: The
     :param configuration: The configuration message.
+    :param current_time: Used to set start time if interval is supplied (ms).
     :return: The created histogrammer.
     """
     histograms = HistogramFactory.generate(configuration)
     start = configuration["start"] if "start" in configuration else None
     stop = configuration["stop"] if "stop" in configuration else None
 
-    # Interval is configured in seconds but needs to be converted to nanoseconds
-    interval = None
-    if "interval" in configuration:
-        interval = configuration["interval"] * 10 ** 9
+    # Interval is configured in seconds but needs to be converted to milliseconds
+    interval = (
+        configuration["interval"] * 10 ** 3 if "interval" in configuration else None
+    )
 
-    return Histogrammer(producer, histograms, start, stop, interval)
+    if interval and (start or stop):
+        raise Exception(
+            "Cannot define 'interval' in combination with start and/or stop"
+        )
+
+    if interval and interval < 0:
+        raise Exception("Interval cannot be negative")
+
+    if interval:
+        start = int(current_time) if current_time else int(time.time() * 1000)
+        stop = start + interval
+
+    return Histogrammer(producer, histograms, start, stop)
 
 
 class Histogrammer:
-    def __init__(self, producer, histograms, start=None, stop=None, interval=None):
+    def __init__(self, producer, histograms, start=None, stop=None):
         """
         Constructor.
 
@@ -44,27 +58,15 @@ class Histogrammer:
         :param histograms: The histograms.
         :param start: When to start histogramming from.
         :param stop: When to histogram until.
-        :param interval: How long to histogram for from "now".
         """
         self.histograms = histograms
         self.hist_sink = HistogramSink(producer)
         self.start = start
         self.stop = stop
-        self.interval = interval
         self._stop_time_exceeded = False
         self._stop_publishing = False
         self._started = False
-
-        self._check_inputs()
-
-    def _check_inputs(self):
-        if self.interval and (self.start or self.stop):
-            raise Exception(
-                "Cannot define 'interval' in combination with start and/or stop"
-            )
-
-        if self.interval and self.interval < 0:
-            raise Exception("Interval cannot be negative")
+        self._stop_leeway = 2000
 
     def add_data(self, event_buffer, simulation=False):
         """
@@ -73,28 +75,23 @@ class Histogrammer:
         :param event_buffer: The new data received.
         :param simulation: Indicates whether in simulation.
         """
-        self._started = True
-
         for hist in self.histograms:
-            for b in event_buffer:
-                if self.interval and not self.start:
-                    # First time determine the start and stop times from the
-                    # interval and the pulse read.
-                    self.start = b["pulse_time"]
-                    self.stop = self.start + self.interval
+            for msg_time, msg_offset, msg in event_buffer:
 
                 if self.start:
-                    if b["pulse_time"] < self.start:
+                    if msg_time < self.start:
                         continue
                 if self.stop:
-                    if b["pulse_time"] > self.stop:
+                    if msg_time > self.stop:
                         self._stop_time_exceeded = True
                         continue
 
-                pt = b["pulse_time"]
-                x = b["tofs"]
-                y = b["det_ids"]
-                src = b["source"] if not simulation else hist.source
+                self._started = True
+
+                pt = msg["pulse_time"]
+                x = msg["tofs"]
+                y = msg["det_ids"]
+                src = msg["source"] if not simulation else hist.source
                 hist.add_data(pt, x, y, src)
 
     def publish_histograms(self, timestamp=0):
@@ -112,13 +109,14 @@ class Histogrammer:
 
     def _generate_info(self, histogram):
         info = {"id": histogram.identifier}
-        if not self._started:
-            info["state"] = HISTOGRAM_STATES["NOT_STARTED"]
-        elif self._stop_time_exceeded:
+        if self._stop_time_exceeded:
             info["state"] = HISTOGRAM_STATES["FINISHED"]
             self._stop_publishing = True
-        else:
+        elif self._started:
             info["state"] = HISTOGRAM_STATES["COUNTING"]
+        else:
+            info["state"] = HISTOGRAM_STATES["NOT_STARTED"]
+
         return info
 
     def clear_histograms(self):
@@ -140,3 +138,24 @@ class Histogrammer:
             results.append({"last_pulse_time": h.last_pulse_time, "sum": h.data.sum()})
 
         return results
+
+    def check_stop_time_exceeded(self, timestamp: int):
+        """
+        Checks whether the stop time has been exceeded, if so it stops the histogramming.
+
+        :param timestamp: The timestamp to check against
+        :return: True if exceeded
+        """
+        # Do nothing if there is no stop time
+        if self.stop is None:
+            return False
+
+        # Already stopped
+        if self._stop_time_exceeded:
+            return True
+
+        # Give it some leeway
+        if timestamp > self.stop + self._stop_leeway:
+            self._stop_time_exceeded = True
+
+        return self._stop_time_exceeded

--- a/main.py
+++ b/main.py
@@ -136,7 +136,7 @@ class Main:
                         # Publish initial empty histograms.
                         self.histogrammer.publish_histograms()
                 except Exception as error:
-                    logging.error(f"Could not handle configuration: {error}")
+                    logging.error("Could not handle configuration: %s", error)
 
             if self.event_source is None:
                 # No event source means we are waiting for a configuration.
@@ -172,13 +172,13 @@ class Main:
             self.histogrammer.publish_histograms()
 
             hist_stats = self.histogrammer.get_histogram_stats()
-            logging.info(json.dumps(hist_stats))
+            logging.info("%s", json.dumps(hist_stats))
 
             if self.stats_publisher:
                 try:
                     self.stats_publisher.send_histogram_stats(hist_stats)
                 except Exception as error:
-                    logging.error(f"Could not publish statistics: {error}")
+                    logging.error("Could not publish statistics: %s", error)
 
             time.sleep(0.5)
 
@@ -191,7 +191,7 @@ class Main:
         logging.info("Creating configuration consumer")
         while not are_kafka_settings_valid(self.config_brokers, [self.config_topic]):
             logging.error(
-                f"Could not connect to Kafka brokers or topic for configuration - will retry shortly"
+                "Could not connect to Kafka brokers or topic for configuration - will retry shortly"
             )
             time.sleep(5)
         self.config_listener = ConfigListener(
@@ -249,9 +249,9 @@ class Main:
                     self.event_source = self.configure_event_source(msg)
                 self.configure_histograms(msg)
             except Exception as error:
-                logging.error(f"Could not use received configuration: {error}")
+                logging.error("Could not use received configuration: %s", error)
         else:
-            logging.warning(f'Unknown command received: {msg["cmd"]}')
+            logging.warning("Unknown command received: %s", msg["cmd"])
 
 
 if __name__ == "__main__":

--- a/tests/test_config_listener.py
+++ b/tests/test_config_listener.py
@@ -13,27 +13,27 @@ class TestConfigListener:
         assert not self.config_listener.check_for_messages()
 
     def test_when_message_waiting_then_checking_returns_that_message_waiting(self):
-        self.mock_consumer.add_messages(['"message1"'])
+        self.mock_consumer.add_messages([(0, 0, '"message1"')])
 
         assert self.config_listener.check_for_messages()
 
     def test_when_waiting_message_not_consumed_checking_again_still_returns_message_waiting(
         self
     ):
-        self.mock_consumer.add_messages(['"message1"'])
+        self.mock_consumer.add_messages([(0, 0, '"message1"')])
         self.config_listener.check_for_messages()
 
         assert self.config_listener.check_for_messages()
 
     def test_consuming_waiting_message_get_message(self):
-        self.mock_consumer.add_messages(['"message1"'])
+        self.mock_consumer.add_messages([(0, 0, '"message1"')])
         self.config_listener.check_for_messages()
 
-        msg = self.config_listener.consume_message()
+        _, _, msg = self.config_listener.consume_message()
         assert msg == "message1"
 
     def test_consuming_waiting_message_clears_message_waiting(self):
-        self.mock_consumer.add_messages(['"message1"'])
+        self.mock_consumer.add_messages([(0, 0, '"message1"')])
         self.config_listener.check_for_messages()
 
         _ = self.config_listener.consume_message()
@@ -41,10 +41,12 @@ class TestConfigListener:
         assert not self.config_listener.check_for_messages()
 
     def test_consuming_waiting_message_gets_latest_message(self):
-        self.mock_consumer.add_messages(['"message1"', '"message2"', '"message3"'])
+        self.mock_consumer.add_messages(
+            [(0, 0, '"message1"'), (1, 1, '"message2"'), (2, 2, '"message3"')]
+        )
         self.config_listener.check_for_messages()
 
-        msg = self.config_listener.consume_message()
+        _, _, msg = self.config_listener.consume_message()
         assert msg == "message3"
 
     def test_when_no_messages_trying_to_consume_throws(self):

--- a/tests/test_config_source.py
+++ b/tests/test_config_source.py
@@ -85,10 +85,10 @@ class TestConfigSource:
 
     def test_received_configuration_converted_correctly(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([CONFIG_BASIC_1])
+        mock_consumer.add_messages([(0, 0, CONFIG_BASIC_1)])
         src = ConfigSource(mock_consumer)
 
-        config = src.get_new_data()[-1]
+        _, _, config = src.get_new_data()[-1]
 
         assert config["cmd"] == "config"
         assert len(config["data_brokers"]) == 1
@@ -113,10 +113,10 @@ class TestConfigSource:
 
     def test_received_restart_message_converted_correctly(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([RESTART_CMD])
+        mock_consumer.add_messages([(0, 0, RESTART_CMD)])
         src = ConfigSource(mock_consumer)
 
-        message = src.get_new_data()[-1]
+        _, _, message = src.get_new_data()[-1]
 
         assert message["cmd"] == "restart"
 
@@ -129,44 +129,48 @@ class TestConfigSource:
 
     def test_if_multiple_new_messages_gets_the_most_recent_one(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([CONFIG_BASIC_1, CONFIG_BASIC_1, CONFIG_BASIC_2])
+        mock_consumer.add_messages(
+            [(0, 0, CONFIG_BASIC_1), (1, 1, CONFIG_BASIC_1), (2, 2, CONFIG_BASIC_2)]
+        )
         src = ConfigSource(mock_consumer)
 
-        config = src.get_new_data()[-1]
+        _, _, config = src.get_new_data()[-1]
 
         assert config["data_brokers"][0] == "differenthost:9092"
 
     def test_malformed_message_is_ignored(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([INVALID_JSON])
+        mock_consumer.add_messages([(0, 0, INVALID_JSON)])
         src = ConfigSource(mock_consumer)
 
         assert len(src.get_new_data()) == 0
 
     def test_if_multiple_new_messages_gets_the_most_recent_valid_one(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([CONFIG_BASIC_1, CONFIG_BASIC_2, INVALID_JSON])
+        mock_consumer.add_messages(
+            [(0, 0, CONFIG_BASIC_1), (1, 1, CONFIG_BASIC_2), (2, 2, INVALID_JSON)]
+        )
         src = ConfigSource(mock_consumer)
 
-        config = src.get_new_data()[-1]
+        _, _, config = src.get_new_data()[-1]
 
         assert config["data_brokers"][0] == "differenthost:9092"
 
     def test_start_and_stop_time_converted_correctly(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([CONFIG_START_AND_STOP])
+        mock_consumer.add_messages([(0, 0, CONFIG_START_AND_STOP)])
         src = ConfigSource(mock_consumer)
 
-        config = src.get_new_data()[-1]
+        _, _, config = src.get_new_data()[-1]
 
         assert config["start"] == 1558596988319002000
         assert config["stop"] == 1558597215933670000
 
     def test_interval_converted_correctly(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
-        mock_consumer.add_messages([CONFIG_INTERVAL])
+        mock_consumer.add_messages([(0, 0, CONFIG_INTERVAL)])
         src = ConfigSource(mock_consumer)
 
-        config = src.get_new_data()[-1]
+        _, _, config = src.get_new_data()[-1]
 
         assert config["interval"] == 5000

--- a/tests/test_det_histogram.py
+++ b/tests/test_det_histogram.py
@@ -1,0 +1,121 @@
+import pytest
+import numpy as np
+from histograms.det_histogram import DetHistogram
+
+
+class TestDetHistogram:
+    @pytest.fixture(autouse=True)
+    def prepare(self):
+        self.NOT_USED = -1
+        self.pulse_time = 1234
+        self.tof_range = (0, 10)
+        self.det_range = (0, 19)
+        self.num_dets = 20
+        self.width = 5
+        self.data = np.array([x for x in range(self.det_range[1] + 1)])
+        self.hist = DetHistogram("topic", self.tof_range, self.det_range, self.width)
+
+    def test_if_width_is_not_multiple_of_detector_range_then_throws(self):
+        width = 5
+        det_range = (0, 23)
+
+        with pytest.raises(Exception):
+            DetHistogram("topic", self.tof_range, det_range, width)
+
+    def test_starting_from_non_zero_detector_okay_if_width_is_multiple_of_detector_range(
+        self
+    ):
+        width = 5
+        det_range = (2, 21)
+
+        DetHistogram("topic", self.tof_range, det_range, width)
+
+    def test_on_construction_histogram_is_uninitialised(self):
+        assert self.hist.x_edges is not None
+        assert self.hist.shape == (20,)
+        assert len(self.hist.x_edges) == 21
+        assert self.hist.x_edges[0] == self.data[0]
+        assert self.hist.x_edges[-1] == 19
+        assert self.hist.data.sum() == 0
+
+    def test_adding_data_to_initialised_histogram_new_data_is_added(self):
+        self.hist.add_data(self.pulse_time, [], self.data)
+        first_sum = self.hist.data.sum()
+
+        # Add the data again
+        self.hist.add_data(self.pulse_time, [], self.data)
+
+        # Sum should be double
+        assert self.hist.data.sum() == first_sum * 2
+
+    def test_adding_data_outside_initial_bins_is_ignored(self):
+        self.hist.add_data(self.pulse_time, [], self.data)
+        first_sum = self.hist.data.sum()
+        x_edges = self.hist.x_edges[:]
+
+        # Add data that is outside the edges
+        new_data = np.array([x + self.num_dets + 1 for x in range(self.num_dets)])
+        self.hist.add_data(self.pulse_time, [], new_data)
+
+        # Sum should not change
+        assert self.hist.data.sum() == first_sum
+        # Edges should not change
+        assert np.array_equal(self.hist.x_edges, x_edges)
+
+    def test_adding_data_of_specific_shape_is_captured(self):
+        data = [12, 12, 13, 13, 13, 14, 14]
+        self.hist.add_data(self.pulse_time, [], data)
+
+        assert self.hist.data.sum() == len(data)
+        assert self.hist.data[12] == 2
+        assert self.hist.data[13] == 3
+        assert self.hist.data[14] == 2
+
+    def test_if_no_id_supplied_then_defaults_to_empty_string(self):
+        assert self.hist.identifier == ""
+
+    def test_id_supplied_then_is_set(self):
+        example_id = "abcdef"
+        hist = DetHistogram(
+            "topic1", self.tof_range, self.det_range, self.width, identifier=example_id
+        )
+        assert hist.identifier == example_id
+
+    def test_only_data_with_correct_source_is_added(self):
+        hist = DetHistogram(
+            "topic", self.tof_range, self.det_range, self.width, source="source1"
+        )
+
+        hist.add_data(self.pulse_time, [], self.data, source="source1")
+        hist.add_data(self.pulse_time, [], self.data, source="source1")
+        hist.add_data(self.pulse_time, [], self.data, source="OTHER")
+
+        assert hist.data.sum() == 38
+
+    def test_clearing_histogram_data_clears_histogram(self):
+        self.hist.add_data(self.pulse_time, [], self.data)
+
+        self.hist.clear_data()
+
+        assert self.hist.data.sum() == 0
+
+    def test_after_clearing_histogram_can_add_data(self):
+        self.hist.add_data(self.pulse_time, [], self.data)
+        self.hist.clear_data()
+
+        self.hist.add_data(self.pulse_time, [], self.data)
+
+        assert self.hist.shape == (self.num_dets,)
+        assert self.hist.data.sum() == 19
+
+    def test_adding_empty_data_does_nothing(self):
+        self.hist.add_data(self.pulse_time, [], [])
+
+        assert self.hist.data.sum() == 0
+
+    def test_histogram_keeps_track_of_last_pulse_time_processed(self):
+        self.hist.add_data(1234, [], self.data)
+        self.hist.add_data(1235, [], self.data)
+        self.hist.add_data(1236, [], self.data)
+
+        assert self.hist.last_pulse_time == 1236

--- a/tests/test_det_histogram.py
+++ b/tests/test_det_histogram.py
@@ -6,11 +6,10 @@ from histograms.det_histogram import DetHistogram
 class TestDetHistogram:
     @pytest.fixture(autouse=True)
     def prepare(self):
-        self.NOT_USED = -1
         self.pulse_time = 1234
         self.tof_range = (0, 10)
         self.det_range = (0, 19)
-        self.num_dets = 20
+        self.num_dets = self.det_range[1] - self.det_range[0] + 1
         self.width = 5
         self.data = np.array([x for x in range(self.det_range[1] + 1)])
         self.hist = DetHistogram("topic", self.tof_range, self.det_range, self.width)
@@ -32,10 +31,13 @@ class TestDetHistogram:
 
     def test_on_construction_histogram_is_uninitialised(self):
         assert self.hist.x_edges is not None
-        assert self.hist.shape == (20,)
-        assert len(self.hist.x_edges) == 21
+        assert self.hist.shape == (5, 4)
+        assert len(self.hist.x_edges) == 6
+        assert len(self.hist.y_edges) == 5
         assert self.hist.x_edges[0] == self.data[0]
-        assert self.hist.x_edges[-1] == 19
+        assert self.hist.x_edges[-1] == 5
+        assert self.hist.y_edges[0] == self.data[0]
+        assert self.hist.y_edges[-1] == 4
         assert self.hist.data.sum() == 0
 
     def test_adding_data_to_initialised_histogram_new_data_is_added(self):
@@ -63,13 +65,13 @@ class TestDetHistogram:
         assert np.array_equal(self.hist.x_edges, x_edges)
 
     def test_adding_data_of_specific_shape_is_captured(self):
-        data = [12, 12, 13, 13, 13, 14, 14]
+        data = [10, 10, 11, 11, 11, 12, 12]
         self.hist.add_data(self.pulse_time, [], data)
 
         assert self.hist.data.sum() == len(data)
-        assert self.hist.data[12] == 2
-        assert self.hist.data[13] == 3
-        assert self.hist.data[14] == 2
+        assert self.hist.data[2][2] == 2
+        assert self.hist.data[2][3] == 3
+        assert self.hist.data[3][0] == 2
 
     def test_if_no_id_supplied_then_defaults_to_empty_string(self):
         assert self.hist.identifier == ""
@@ -105,7 +107,7 @@ class TestDetHistogram:
 
         self.hist.add_data(self.pulse_time, [], self.data)
 
-        assert self.hist.shape == (self.num_dets,)
+        assert self.hist.shape == (5, 4)
         assert self.hist.data.sum() == 19
 
     def test_adding_empty_data_does_nothing(self):

--- a/tests/test_histogram1d.py
+++ b/tests/test_histogram1d.py
@@ -63,7 +63,9 @@ class TestHistogram1d:
         def _preprocess(pulse_time, x):
             raise Exception("Preprocessing failed.")
 
-        self.hist = Histogram1d("topic1", self.num_bins, self.range, _preprocess)
+        self.hist = Histogram1d(
+            "topic1", self.num_bins, self.range, preprocessor=_preprocess
+        )
         self.hist.add_data(self.pulse_time, self.data)
 
     def test_only_data_with_correct_source_is_added(self):
@@ -129,3 +131,12 @@ class TestHistogram1d:
         example_id = "abcdef"
         hist = Histogram1d("topic1", self.num_bins, self.range, identifier=example_id)
         assert hist.identifier == example_id
+
+    def test_if_det_id_is_out_of_range_then_it_is_ignored(self):
+        hist = Histogram1d("topic1", self.num_bins, self.range, (10, 20))
+        tof_data = [0, 1, 2, 3, 4]
+        det_data = [0, 10, 20, 30, 40]
+
+        hist.add_data(12345, tof_data, det_data)
+
+        assert hist.data.sum() == 2

--- a/tests/test_histogram_factory.py
+++ b/tests/test_histogram_factory.py
@@ -100,22 +100,6 @@ MISSING_HISTOGRAMS_CONFIG = {
     "data_topics": ["my_topic"],
 }
 
-# This throws because the width is not a divisor of the number of detectors.
-INVALID_WIDTH_CONFIG = {
-    "data_brokers": ["localhost:9092", "someserver:9092"],
-    "data_topics": ["my_topic"],
-    "histograms": [
-        {
-            "type": "dethist",
-            "tof_range": [0, 4000],
-            "det_range": [0, 3999],
-            "width": 4005,
-            "topic": "topic3",
-            "source": "source3",
-        }
-    ],
-}
-
 
 class TestHistogramFactory:
     @pytest.fixture(autouse=True)
@@ -180,10 +164,5 @@ class TestHistogramFactory:
         histograms = HistogramFactory.generate(VALID_CONFIG_WITH_ID)
 
         assert histograms[0].identifier == "123456"
-
-    def test_if_width_invalid_for_det_histogram_then_histogram_is_not_created(self):
-        histograms = HistogramFactory.generate(INVALID_WIDTH_CONFIG)
-
-        assert len(histograms) == 0
 
     # TODO: More tests for when data is missing/invalid for 2d plots

--- a/tests/test_histogram_factory.py
+++ b/tests/test_histogram_factory.py
@@ -34,8 +34,9 @@ VALID_CONFIG = {
         {
             "type": "dethist",
             "tof_range": [0, 4000],
-            "det_range": [0, 3999],
-            "width": 4000,
+            "det_range": [0, 99],
+            "width": 10,
+            "height": 10,
             "topic": "topic3",
             "source": "source3",
         },
@@ -144,7 +145,9 @@ class TestHistogramFactory:
 
         assert isinstance(histograms[3], DetHistogram)
         assert histograms[3].tof_range == (0, 4000)
-        assert histograms[3].num_bins == 4000
+        assert histograms[3].num_bins == 100
+        assert histograms[3].height == 10
+        assert histograms[3].width == 10
         assert histograms[3].topic == "topic3"
         assert histograms[3].source == "source3"
 

--- a/tests/test_histogram_factory.py
+++ b/tests/test_histogram_factory.py
@@ -3,6 +3,7 @@ from histograms.histogram_factory import HistogramFactory
 from histograms.histogram1d import Histogram1d
 from histograms.histogram2d import Histogram2d
 from histograms.single_event_histogram1d import SingleEventHistogram1d
+from histograms.det_histogram import DetHistogram
 
 
 VALID_CONFIG = {
@@ -29,6 +30,14 @@ VALID_CONFIG = {
             "num_bins": 200,
             "topic": "topic2",
             "source": "source2",
+        },
+        {
+            "type": "dethist",
+            "tof_range": [0, 4000],
+            "det_range": [0, 3999],
+            "width": 4000,
+            "topic": "topic3",
+            "source": "source3",
         },
     ],
 }
@@ -116,6 +125,12 @@ class TestHistogramFactory:
         assert histograms[2].num_bins == 200
         assert histograms[2].topic == "topic2"
         assert histograms[2].source == "source2"
+
+        assert isinstance(histograms[3], DetHistogram)
+        assert histograms[3].tof_range == (0, 4000)
+        assert histograms[3].num_bins == 4000
+        assert histograms[3].topic == "topic3"
+        assert histograms[3].source == "source3"
 
     def test_throws_if_tof_missing(self):
         with pytest.raises(Exception):

--- a/tests/test_histogram_factory.py
+++ b/tests/test_histogram_factory.py
@@ -99,6 +99,22 @@ MISSING_HISTOGRAMS_CONFIG = {
     "data_topics": ["my_topic"],
 }
 
+# This throws because the width is not a divisor of the number of detectors.
+INVALID_WIDTH_CONFIG = {
+    "data_brokers": ["localhost:9092", "someserver:9092"],
+    "data_topics": ["my_topic"],
+    "histograms": [
+        {
+            "type": "dethist",
+            "tof_range": [0, 4000],
+            "det_range": [0, 3999],
+            "width": 4005,
+            "topic": "topic3",
+            "source": "source3",
+        }
+    ],
+}
+
 
 class TestHistogramFactory:
     @pytest.fixture(autouse=True)
@@ -132,17 +148,20 @@ class TestHistogramFactory:
         assert histograms[3].topic == "topic3"
         assert histograms[3].source == "source3"
 
-    def test_throws_if_tof_missing(self):
-        with pytest.raises(Exception):
-            _ = HistogramFactory.generate(MISSING_TOF_CONFIG)
+    def test_if_tof_missing_then_histogram_not_created(self):
+        histograms = HistogramFactory.generate(MISSING_TOF_CONFIG)
 
-    def test_throws_if_bins_missing(self):
-        with pytest.raises(Exception):
-            _ = HistogramFactory.generate(MISSING_BINS_CONFIG)
+        assert len(histograms) == 0
 
-    def test_throws_if_bins_and_tof_missing(self):
-        with pytest.raises(Exception):
-            _ = HistogramFactory.generate(MISSING_TOF_AND_BINS_CONFIG)
+    def test_if_bins_missing_then_histogram_not_created(self):
+        histograms = HistogramFactory.generate(MISSING_BINS_CONFIG)
+
+        assert len(histograms) == 0
+
+    def test_if_bins_and_tof_missing_then_histogram_not_created(self):
+        histograms = HistogramFactory.generate(MISSING_TOF_AND_BINS_CONFIG)
+
+        assert len(histograms) == 0
 
     def test_when_no_histograms_defined_nothing_happens(self):
         histograms = HistogramFactory.generate(MISSING_HISTOGRAMS_CONFIG)
@@ -159,4 +178,9 @@ class TestHistogramFactory:
 
         assert histograms[0].identifier == "123456"
 
-    # TODO: More tests for when data is missing
+    def test_if_width_invalid_for_det_histogram_then_histogram_is_not_created(self):
+        histograms = HistogramFactory.generate(INVALID_WIDTH_CONFIG)
+
+        assert len(histograms) == 0
+
+    # TODO: More tests for when data is missing/invalid for 2d plots

--- a/tests/test_histogram_source.py
+++ b/tests/test_histogram_source.py
@@ -31,9 +31,12 @@ class TestHistogramSource:
         mock_consumer = MockConsumer(["broker1"], ["topic1"])
         mock_consumer.add_messages([TEST_MESSAGE] * 5)
         hs = HistogramSource(mock_consumer)
+
         data = hs.get_new_data()
+        _, _, message = data[0]
+
         assert len(data) == 5
-        assert data[0] == TEST_MESSAGE
+        assert message == TEST_MESSAGE
 
     def test_deserialising_invalid_fb_does_not_throw(self):
         mock_consumer = MockConsumer(["broker1"], ["topic1"])

--- a/tests/test_histogrammer.py
+++ b/tests/test_histogrammer.py
@@ -263,7 +263,7 @@ class TestHistogrammer:
 
         data = deserialise_hs00(self.mock_producer.messages[0][1])
         info = json.loads(data["info"])
-        assert info["state"] == HISTOGRAM_STATES["NOT_STARTED"]
+        assert info["state"] == HISTOGRAM_STATES["INITIALISED"]
 
     def test_while_counting_published_histogram_is_labelled_to_indicate_counting(self):
         histogrammer = create_histogrammer(self.mock_producer, START_CONFIG)

--- a/tests/test_histogrammer.py
+++ b/tests/test_histogrammer.py
@@ -10,7 +10,7 @@ START_CONFIG = {
     "cmd": "config",
     "data_brokers": ["fakehost:9092"],
     "data_topics": ["LOQ_events"],
-    "start": 1000 * 10 ** 9,
+    "start": 1000 * 10 ** 3,
     "histograms": [
         {
             "type": "hist1d",
@@ -33,7 +33,7 @@ START_2D_CONFIG = {
     "cmd": "config",
     "data_brokers": ["fakehost:9092"],
     "data_topics": ["LOQ_events"],
-    "start": 1000 * 10 ** 9,
+    "start": 1000 * 10 ** 3,
     "histograms": [
         {
             "type": "hist2d",
@@ -58,14 +58,14 @@ NO_HIST_CONFIG = {
     "cmd": "config",
     "data_brokers": ["fakehost:9092"],
     "data_topics": ["LOQ_events"],
-    "start": 1000 * 10 ** 9,
+    "start": 1000 * 10 ** 3,
 }
 
 STOP_CONFIG = {
     "cmd": "config",
     "data_brokers": ["fakehost:9092"],
     "data_topics": ["LOQ_events"],
-    "stop": 1001 * 10 ** 9,
+    "stop": 1001 * 10 ** 3,
     "histograms": [
         {
             "type": "hist1d",
@@ -95,59 +95,109 @@ INTERVAL_CONFIG = {
 # Data in each "pulse" increases by factor of 2, that way we can know which
 # messages were consumed by looking at the histogram sum.
 EVENT_DATA = [
-    {"pulse_time": 998 * 10 ** 9, "tofs": [1], "det_ids": None, "source": "simulator"},
-    {
-        "pulse_time": 999 * 10 ** 9,
-        "tofs": [1, 2],
-        "det_ids": [1, 2],
-        "source": "simulator",
-    },
-    {
-        "pulse_time": 1000 * 10 ** 9,
-        "tofs": [1, 2, 3, 4],
-        "det_ids": [1, 2, 3, 4],
-        "source": "simulator",
-    },
-    {
-        "pulse_time": 1001 * 10 ** 9,
-        "tofs": [1, 2, 3, 4, 5, 6, 7, 8],
-        "det_ids": [1, 2, 3, 4, 5, 6, 7, 8],
-        "source": "simulator",
-    },
-    {
-        "pulse_time": 1002 * 10 ** 9,
-        "tofs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        "det_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        "source": "simulator",
-    },
+    (
+        998 * 10 ** 3,
+        0,
+        {
+            "pulse_time": 998 * 10 ** 9,
+            "tofs": [1],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
+    (
+        999 * 10 ** 3,
+        1,
+        {
+            "pulse_time": 999 * 10 ** 9,
+            "tofs": [1, 2],
+            "det_ids": [1, 2],
+            "source": "simulator",
+        },
+    ),
+    (
+        1000 * 10 ** 3,
+        2,
+        {
+            "pulse_time": 1000 * 10 ** 9,
+            "tofs": [1, 2, 3, 4],
+            "det_ids": [1, 2, 3, 4],
+            "source": "simulator",
+        },
+    ),
+    (
+        1001 * 10 ** 3,
+        3,
+        {
+            "pulse_time": 1001 * 10 ** 9,
+            "tofs": [1, 2, 3, 4, 5, 6, 7, 8],
+            "det_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+            "source": "simulator",
+        },
+    ),
+    (
+        1002 * 10 ** 3,
+        4,
+        {
+            "pulse_time": 1002 * 10 ** 9,
+            "tofs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            "det_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            "source": "simulator",
+        },
+    ),
 ]
 
 UNORDERED_EVENT_DATA = [
-    {
-        "pulse_time": 1000 * 10 ** 9,
-        "tofs": [1, 2, 3, 4],
-        "det_ids": None,
-        "source": "simulator",
-    },
-    {
-        "pulse_time": 1001 * 10 ** 9,
-        "tofs": [1, 2, 3, 4, 5, 6, 7, 8],
-        "det_ids": None,
-        "source": "simulator",
-    },
-    {
-        "pulse_time": 1002 * 10 ** 9,
-        "tofs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        "det_ids": None,
-        "source": "simulator",
-    },
-    {"pulse_time": 998 * 10 ** 9, "tofs": [1], "det_ids": None, "source": "simulator"},
-    {
-        "pulse_time": 999 * 10 ** 9,
-        "tofs": [1, 2],
-        "det_ids": None,
-        "source": "simulator",
-    },
+    (
+        1000 * 10 ** 3,
+        0,
+        {
+            "pulse_time": 1000 * 10 ** 9,
+            "tofs": [1, 2, 3, 4],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
+    (
+        1001 * 10 ** 3,
+        1,
+        {
+            "pulse_time": 1001 * 10 ** 9,
+            "tofs": [1, 2, 3, 4, 5, 6, 7, 8],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
+    (
+        1002 * 10 ** 3,
+        2,
+        {
+            "pulse_time": 1002 * 10 ** 9,
+            "tofs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
+    (
+        998 * 10 ** 3,
+        3,
+        {
+            "pulse_time": 998 * 10 ** 9,
+            "tofs": [1],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
+    (
+        999 * 10 ** 3,
+        4,
+        {
+            "pulse_time": 999 * 10 ** 9,
+            "tofs": [1, 2],
+            "det_ids": None,
+            "source": "simulator",
+        },
+    ),
 ]
 
 
@@ -173,12 +223,28 @@ class TestHistogrammer:
         assert histogrammer.histograms[0].data.sum() == 28
         assert histogrammer.histograms[1].data.sum() == 28
 
+    def test_histograms_are_zero_if_all_data_before_start(self):
+        config = copy.deepcopy(START_CONFIG)
+        config["start"] = 1100 * 10 ** 3
+        histogrammer = create_histogrammer(self.mock_producer, config)
+        histogrammer.add_data(EVENT_DATA)
+
+        assert histogrammer.histograms[0].data.sum() == 0
+
     def test_data_only_add_up_to_stop_time(self):
         histogrammer = create_histogrammer(self.mock_producer, STOP_CONFIG)
 
         histogrammer.add_data(EVENT_DATA)
 
         assert histogrammer.histograms[0].data.sum() == 15
+
+    def test_histograms_are_zero_if_all_data_later_than_stop(self):
+        config = copy.deepcopy(STOP_CONFIG)
+        config["stop"] = 900 * 10 ** 3
+        histogrammer = create_histogrammer(self.mock_producer, config)
+        histogrammer.add_data(EVENT_DATA)
+
+        assert histogrammer.histograms[0].data.sum() == 0
 
     def test_data_out_of_order_does_not_add_data_before_start(self):
         histogrammer = create_histogrammer(self.mock_producer, START_CONFIG)
@@ -293,21 +359,15 @@ class TestHistogrammer:
         with pytest.raises(Exception):
             create_histogrammer(self.mock_producer, config)
 
-    def test_if_interval_defined_then_start_and_stop_are_not_initialised(self):
-        histogrammer = create_histogrammer(self.mock_producer, INTERVAL_CONFIG)
+    def test_if_interval_defined_then_start_and_stop_are_initialised(self):
+        current_time = 1000
+        interval = INTERVAL_CONFIG["interval"] * 10 ** 3
+        histogrammer = create_histogrammer(
+            self.mock_producer, INTERVAL_CONFIG, current_time
+        )
 
-        assert histogrammer.start is None
-        assert histogrammer.stop is None
-
-    def test_if_interval_defined_then_start_and_stop_are_initialised_after_first_data(
-        self
-    ):
-        histogrammer = create_histogrammer(self.mock_producer, INTERVAL_CONFIG)
-
-        histogrammer.add_data(EVENT_DATA)
-
-        assert histogrammer.start == 998 * 10 ** 9
-        assert histogrammer.stop == 1003 * 10 ** 9
+        assert histogrammer.start == current_time
+        assert histogrammer.stop == current_time + interval
 
     def test_if_interval_negative_then_throws(self):
         config = copy.deepcopy(INTERVAL_CONFIG)
@@ -315,11 +375,6 @@ class TestHistogrammer:
 
         with pytest.raises(Exception):
             create_histogrammer(self.mock_producer, config)
-
-    def test_interval_is_converted_to_nanoseconds(self):
-        histogrammer = create_histogrammer(self.mock_producer, INTERVAL_CONFIG)
-
-        assert histogrammer.interval == 5 * 10 ** 9
 
     def test_clear_histograms_empties_all_histograms(self):
         histogrammer = create_histogrammer(self.mock_producer, START_CONFIG)
@@ -329,3 +384,33 @@ class TestHistogrammer:
 
         assert histogrammer.histograms[0].data.sum() == 0
         assert histogrammer.histograms[1].data.sum() == 0
+
+    def test_if_no_data_after_start_time_and_stop_time_exceeded_histogram_is_finished(
+        self
+    ):
+        config = copy.deepcopy(START_CONFIG)
+        config["start"] = 1003 * 10 ** 3
+        config["stop"] = 1005 * 10 ** 3
+
+        histogrammer = create_histogrammer(self.mock_producer, config)
+        # Supply a time significantly after the original stop time because of
+        # leeway
+        finished = histogrammer.check_stop_time_exceeded(config["stop"] * 1.1)
+
+        info = histogrammer._generate_info(histogrammer.histograms[0])
+        assert finished
+        assert info["state"] == HISTOGRAM_STATES["FINISHED"]
+
+    def test_if_no_data_after_start_time_and_stop_time_not_exceeded_histogram_is_not_finished(
+        self
+    ):
+        config = copy.deepcopy(START_CONFIG)
+        config["start"] = 1003 * 10 ** 3
+        config["stop"] = 1005 * 10 ** 3
+
+        histogrammer = create_histogrammer(self.mock_producer, config)
+        finished = histogrammer.check_stop_time_exceeded(config["stop"] * 0.9)
+
+        info = histogrammer._generate_info(histogrammer.histograms[0])
+        assert not finished
+        assert info["state"] != HISTOGRAM_STATES["FINISHED"]

--- a/tools/view_output_messages.py
+++ b/tools/view_output_messages.py
@@ -1,0 +1,63 @@
+import argparse
+from kafka import KafkaConsumer, TopicPartition
+from endpoints.serialisation import deserialise_hs00
+
+
+def main(brokers, topic):
+    consumer = KafkaConsumer(bootstrap_servers=brokers)
+    print(f"Topics = {consumer.topics()}")
+
+    tp = TopicPartition(topic, 0)
+    consumer.assign([tp])
+
+    # Move to one from the end
+    consumer.seek_to_end(tp)
+    end = consumer.position(tp)
+    consumer.seek(tp, end - 1)
+
+    while True:
+        data = []
+
+        while not data:
+            data = consumer.poll(5)
+
+        for message in data[tp]:
+            print(
+                "%s %s:%d:%d: key=%s value=%s"
+                % (
+                    message.timestamp,
+                    message.topic,
+                    message.partition,
+                    message.offset,
+                    message.key,
+                    message.value[0:20],
+                )
+            )
+            ans = deserialise_hs00(message.value)
+            print(ans)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    required_args = parser.add_argument_group("required arguments")
+    required_args.add_argument(
+        "-b",
+        "--brokers",
+        type=str,
+        nargs="+",
+        help="the broker addresses",
+        required=True,
+    )
+
+    required_args.add_argument(
+        "-t",
+        "--topic",
+        type=str,
+        help="the topic where just-bin-it is writing histogram data",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    main(args.brokers, args.topic)


### PR DESCRIPTION
For a counting interval, it now uses the system time for calculating the time to start counting from and to.

This means if there is no data coming in, it doesn't return early. This was a bug seen at V20