### PR TITLE
DM-1899: move to using streaming module for hs00

### DIFF
--- a/bin/viewer.py
+++ b/bin/viewer.py
@@ -21,13 +21,13 @@ def convert_for_plotting(histogram):
 
     h = Histogram()
 
-    if len(histogram["dims"]) == 1:
+    if len(histogram["dim_metadata"]) == 1:
         # 1-D
-        h.x_edges = np.array(histogram["dims"][0]["edges"])
+        h.x_edges = np.array(histogram["dim_metadata"][0]["bin_boundaries"])
     else:
         # 2-D
-        h.x_edges = np.array(histogram["dims"][0]["edges"])
-        h.y_edges = np.array(histogram["dims"][1]["edges"])
+        h.x_edges = np.array(histogram["dim_metadata"][0]["bin_boundaries"])
+        h.y_edges = np.array(histogram["dim_metadata"][1]["bin_boundaries"])
 
     h.data = np.array(histogram["data"])
 

--- a/just_bin_it/endpoints/serialisation.py
+++ b/just_bin_it/endpoints/serialisation.py
@@ -1,10 +1,6 @@
 import flatbuffers
 import streaming_data_types.histogram_hs00 as hs00
 import just_bin_it.fbschemas.ev42.EventMessage as EventMessage
-import just_bin_it.fbschemas.hs00.ArrayDouble as ArrayDouble
-import just_bin_it.fbschemas.hs00.DimensionMetaData as DimensionMetaData
-import just_bin_it.fbschemas.hs00.EventHistogram as EventHistogram
-from just_bin_it.fbschemas.hs00.Array import Array
 from just_bin_it.exceptions import JustBinItException
 
 
@@ -16,6 +12,50 @@ def get_schema(buf):
     :return: The schema name
     """
     return buf[4:8].decode("utf-8")
+
+
+def deserialise_hs00(buf):
+    """
+    Convert flatbuffer into a histogram.
+
+    :param buf:
+    :return: dict of histogram information
+    """
+    try:
+        return hs00.deserialise_hs00(buf)
+    except Exception as error:
+        raise JustBinItException(f"Could not deserialise hs00 buffer: {error}")
+
+
+def serialise_hs00(histogrammer, timestamp: int = 0, info_message: str = ""):
+    """
+    Serialise a histogram as an hs00 FlatBuffers message.
+
+    :param histogrammer: The histogrammer containing the histogram to serialise.
+    :param timestamp: The timestamp to assign to the histogram.
+    :param info_message: Information to write to the 'info' field.
+    :return: The raw buffer of the FlatBuffers message.
+    """
+
+    dim_metadata = [
+        {"bin_boundaries": histogrammer.x_edges, "length": histogrammer.shape[0]}
+    ]
+
+    if hasattr(histogrammer, "y_edges"):
+        dim_metadata.append(
+            {"bin_boundaries": histogrammer.y_edges, "length": histogrammer.shape[1]}
+        )
+
+    data = {
+        "source": "just-bin-it",
+        "timestamp": timestamp,
+        "current_shape": histogrammer.shape,
+        "dim_metadata": dim_metadata,
+        "data": histogrammer.data,
+        "info": info_message,
+    }
+
+    return hs00.serialise_hs00(data)
 
 
 def deserialise_ev42(buf):
@@ -40,111 +80,6 @@ def deserialise_ev42(buf):
         "tofs": event.TimeOfFlightAsNumpy(),
     }
     return data
-
-
-def deserialise_hs00(buf):
-    """
-    Convert flatbuffer into a histogram.
-
-    :param buf:
-    :return: dict of histogram information
-    """
-    try:
-        return hs00.deserialise_hs00(buf)
-    except Exception as error:
-        raise JustBinItException(f"Could not deserialise hs00 buffer: {error}")
-
-
-def _serialise_metadata(builder, edges, length):
-    ArrayDouble.ArrayDoubleStartValueVector(builder, len(edges))
-    # FlatBuffers builds arrays backwards
-    for x in reversed(edges):
-        builder.PrependFloat64(x)
-    bins = builder.EndVector(len(edges))
-    # Add the bins
-    ArrayDouble.ArrayDoubleStart(builder)
-    ArrayDouble.ArrayDoubleAddValue(builder, bins)
-    pos_bin = ArrayDouble.ArrayDoubleEnd(builder)
-
-    DimensionMetaData.DimensionMetaDataStart(builder)
-    DimensionMetaData.DimensionMetaDataAddLength(builder, length)
-    DimensionMetaData.DimensionMetaDataAddBinBoundaries(builder, pos_bin)
-    DimensionMetaData.DimensionMetaDataAddBinBoundariesType(builder, Array.ArrayDouble)
-    return DimensionMetaData.DimensionMetaDataEnd(builder)
-
-
-def serialise_hs00(histogrammer, timestamp: int = 0, info_message: str = ""):
-    """
-    Serialise a histogram as an hs00 FlatBuffers message.
-
-    :param histogrammer: The histogrammer containing the histogram to serialise.
-    :param timestamp: The timestamp to assign to the histogram.
-    :param info_message: Information to write to the 'info' field.
-    :return: The raw buffer of the FlatBuffers message.
-    """
-    file_identifier = b"hs00"
-
-    builder = flatbuffers.Builder(1024)
-    source = builder.CreateString("just-bin-it")
-    info = builder.CreateString(info_message)
-
-    # Build shape array
-    rank = len(histogrammer.shape)
-    EventHistogram.EventHistogramStartCurrentShapeVector(builder, rank)
-    # FlatBuffers builds arrays backwards
-    for s in reversed(histogrammer.shape):
-        builder.PrependUint32(s)
-    shape = builder.EndVector(rank)
-
-    # Build dimensions metadata
-    # Build the x bins vector
-    metadata = [
-        _serialise_metadata(builder, histogrammer.x_edges, histogrammer.shape[0])
-    ]
-
-    # Build the y bins vector, if present
-    if hasattr(histogrammer, "y_edges"):
-        metadata.append(
-            _serialise_metadata(builder, histogrammer.y_edges, histogrammer.shape[1])
-        )
-
-    EventHistogram.EventHistogramStartDimMetadataVector(builder, rank)
-    # FlatBuffers builds arrays backwards
-    for m in reversed(metadata):
-        builder.PrependUOffsetTRelative(m)
-    metadata_vector = builder.EndVector(rank)
-
-    # Build the data
-    data_len = len(histogrammer.data)
-    if len(histogrammer.shape) == 2:
-        # 2-D data will be flattened into one array
-        data_len = histogrammer.shape[0] * histogrammer.shape[1]
-
-    ArrayDouble.ArrayDoubleStartValueVector(builder, data_len)
-    # FlatBuffers builds arrays backwards
-    for x in reversed(histogrammer.data.flatten()):
-        builder.PrependFloat64(x)
-    data = builder.EndVector(data_len)
-    ArrayDouble.ArrayDoubleStart(builder)
-    ArrayDouble.ArrayDoubleAddValue(builder, data)
-    pos_data = ArrayDouble.ArrayDoubleEnd(builder)
-
-    # Build the actual buffer
-    EventHistogram.EventHistogramStart(builder)
-    EventHistogram.EventHistogramAddInfo(builder, info)
-    EventHistogram.EventHistogramAddData(builder, pos_data)
-    EventHistogram.EventHistogramAddCurrentShape(builder, shape)
-    EventHistogram.EventHistogramAddDimMetadata(builder, metadata_vector)
-    EventHistogram.EventHistogramAddTimestamp(builder, timestamp)
-    EventHistogram.EventHistogramAddSource(builder, source)
-    EventHistogram.EventHistogramAddDataType(builder, Array.ArrayDouble)
-    hist = EventHistogram.EventHistogramEnd(builder)
-    builder.Finish(hist)
-
-    # Generate the output and replace the file_identifier
-    buff = builder.Output()
-    buff[4:8] = file_identifier
-    return buff
 
 
 def serialise_ev42(source_name, message_id, pulse_time, tofs, det_ids):

--- a/just_bin_it/endpoints/sources.py
+++ b/just_bin_it/endpoints/sources.py
@@ -146,7 +146,10 @@ class SimulatedEventSource:
         self.width = 0
         self.height = 0
         self.start = start / 1000
-        self.stop = stop / 1000
+        if stop:
+            self.stop = stop / 1000
+        else:
+            self.stop = None
 
         if config["type"] == "dethist":
             # Different behaviour for this type of histogram
@@ -211,7 +214,7 @@ class SimulatedEventSource:
         return 0
 
     def stop_time_exceeded(self):
-        if time.time() > self.stop:
+        if self.stop and time.time() > self.stop:
             return StopTimeStatus.EXCEEDED
 
         return StopTimeStatus.NOT_EXCEEDED

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyQt5
 pytest
 pytest-cov
 tox
+https://github.com/ess-dmsc/python-streaming-data-types/releases/download/0.3.0/streaming_data_types-0.3.0-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ PyQt5
 pytest
 pytest-cov
 tox
-https://github.com/ess-dmsc/python-streaming-data-types/releases/download/0.3.0/streaming_data_types-0.3.0-py3-none-any.whl
+https://github.com/ess-dmsc/python-streaming-data-types/releases/download/v0.4.0/streaming_data_types-0.4.0-py3-none-any.whl

--- a/tests/test_deserialisation.py
+++ b/tests/test_deserialisation.py
@@ -1,5 +1,4 @@
 import os
-import numpy as np
 import pytest
 import tests
 from just_bin_it.endpoints.serialisation import (
@@ -66,7 +65,6 @@ class TestDeserialisationHs00:
         assert data["info"] == "hello"
 
         assert data["dim_metadata"][0]["length"] == 50
-        assert data["dim_metadata"][0]["type"] == np.float64
         assert len(data["dim_metadata"][0]["bin_boundaries"]) == 51
         assert data["dim_metadata"][0]["bin_boundaries"][0] == 0.0
         assert data["dim_metadata"][0]["bin_boundaries"][50] == 100_000_000.0

--- a/tests/test_deserialisation.py
+++ b/tests/test_deserialisation.py
@@ -60,16 +60,16 @@ class TestDeserialisationHs00:
 
         assert data["source"] == "just-bin-it"
         assert data["timestamp"] == 987_654_321
-        assert data["shape"] == [50]
+        assert data["current_shape"] == [50]
         assert len(data["data"]) == 50
-        assert len(data["dims"]) == 1
+        assert len(data["dim_metadata"]) == 1
         assert data["info"] == "hello"
 
-        assert data["dims"][0]["length"] == 50
-        assert data["dims"][0]["type"] == np.float64
-        assert len(data["dims"][0]["edges"]) == 51
-        assert data["dims"][0]["edges"][0] == 0.0
-        assert data["dims"][0]["edges"][50] == 100_000_000.0
+        assert data["dim_metadata"][0]["length"] == 50
+        assert data["dim_metadata"][0]["type"] == np.float64
+        assert len(data["dim_metadata"][0]["bin_boundaries"]) == 51
+        assert data["dim_metadata"][0]["bin_boundaries"][0] == 0.0
+        assert data["dim_metadata"][0]["bin_boundaries"][50] == 100_000_000.0
 
     def test_if_schema_is_incorrect_then_throws(self):
         new_buf = self.buf[:4] + b"na12" + self.buf[8:]

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -51,7 +51,6 @@ class TestSerialisationHs00:
             hist["dim_metadata"][0]["bin_boundaries"], self.hist_1d.x_edges.tolist()
         )
         assert hist["dim_metadata"][0]["length"] == self.hist_1d.num_bins
-        assert hist["dim_metadata"][0]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_1d.data)
 
     def test_if_timestamp_not_supplied_then_it_is_zero(self):
@@ -68,7 +67,6 @@ class TestSerialisationHs00:
             hist["dim_metadata"][0]["bin_boundaries"], self.hist_1d.x_edges.tolist()
         )
         assert hist["dim_metadata"][0]["length"] == self.hist_1d.num_bins
-        assert hist["dim_metadata"][0]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_1d.data)
 
     def test_serialises_hs00_message_correctly_for_2d(self):
@@ -88,8 +86,6 @@ class TestSerialisationHs00:
         )
         assert hist["dim_metadata"][0]["length"] == self.hist_2d.num_bins
         assert hist["dim_metadata"][1]["length"] == self.hist_2d.num_bins
-        assert hist["dim_metadata"][0]["type"] == np.float64
-        assert hist["dim_metadata"][1]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_2d.data)
 
     def test_serialises_hs00_message_with_info_field_filled_out_correctly(self):

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -46,10 +46,12 @@ class TestSerialisationHs00:
         hist = deserialise_hs00(buf)
         assert hist["source"] == "just-bin-it"
         assert hist["timestamp"] == timestamp
-        assert hist["shape"] == [self.hist_1d.num_bins]
-        assert hist["dims"][0]["edges"] == self.hist_1d.x_edges.tolist()
-        assert hist["dims"][0]["length"] == self.hist_1d.num_bins
-        assert hist["dims"][0]["type"] == np.float64
+        assert hist["current_shape"] == [self.hist_1d.num_bins]
+        assert np.array_equal(
+            hist["dim_metadata"][0]["bin_boundaries"], self.hist_1d.x_edges.tolist()
+        )
+        assert hist["dim_metadata"][0]["length"] == self.hist_1d.num_bins
+        assert hist["dim_metadata"][0]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_1d.data)
 
     def test_if_timestamp_not_supplied_then_it_is_zero(self):
@@ -61,10 +63,12 @@ class TestSerialisationHs00:
         hist = deserialise_hs00(buf)
         assert hist["source"] == "just-bin-it"
         assert hist["timestamp"] == 0
-        assert hist["shape"] == [self.hist_1d.num_bins]
-        assert hist["dims"][0]["edges"] == self.hist_1d.x_edges.tolist()
-        assert hist["dims"][0]["length"] == self.hist_1d.num_bins
-        assert hist["dims"][0]["type"] == np.float64
+        assert hist["current_shape"] == [self.hist_1d.num_bins]
+        assert np.array_equal(
+            hist["dim_metadata"][0]["bin_boundaries"], self.hist_1d.x_edges.tolist()
+        )
+        assert hist["dim_metadata"][0]["length"] == self.hist_1d.num_bins
+        assert hist["dim_metadata"][0]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_1d.data)
 
     def test_serialises_hs00_message_correctly_for_2d(self):
@@ -75,13 +79,17 @@ class TestSerialisationHs00:
 
         hist = deserialise_hs00(buf)
         assert hist["source"] == "just-bin-it"
-        assert hist["shape"] == [self.hist_2d.num_bins, self.hist_2d.num_bins]
-        assert hist["dims"][0]["edges"] == self.hist_2d.x_edges.tolist()
-        assert hist["dims"][1]["edges"] == self.hist_2d.y_edges.tolist()
-        assert hist["dims"][0]["length"] == self.hist_2d.num_bins
-        assert hist["dims"][1]["length"] == self.hist_2d.num_bins
-        assert hist["dims"][0]["type"] == np.float64
-        assert hist["dims"][1]["type"] == np.float64
+        assert hist["current_shape"] == [self.hist_2d.num_bins, self.hist_2d.num_bins]
+        assert np.array_equal(
+            hist["dim_metadata"][0]["bin_boundaries"], self.hist_2d.x_edges.tolist()
+        )
+        assert np.array_equal(
+            hist["dim_metadata"][1]["bin_boundaries"], self.hist_2d.y_edges.tolist()
+        )
+        assert hist["dim_metadata"][0]["length"] == self.hist_2d.num_bins
+        assert hist["dim_metadata"][1]["length"] == self.hist_2d.num_bins
+        assert hist["dim_metadata"][0]["type"] == np.float64
+        assert hist["dim_metadata"][1]["type"] == np.float64
         assert np.array_equal(hist["data"], self.hist_2d.data)
 
     def test_serialises_hs00_message_with_info_field_filled_out_correctly(self):


### PR DESCRIPTION
Now uses the module for hs00.

Still has code for ev42 as that hasn't been added to the module yet.