### PR TITLE
ECDC-2124: implement new config syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ For example:
 }
 ```
 
+##### A note about the old style configuration syntax
+The previous configuration style had the `data_brokers` and `data_topics` defined globally rather per histogram.
+For the short-term, that style of configuration will continue to work but may disappear without warning.
+
 #### Counting for a specified time
 By default just-bin-it will start counting from when it receives the configuration
 command and continue indefinitely.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ from kafka import KafkaProducer
 CONFIG_JSON = b"""
 {
   "cmd": "config",
-  "data_brokers": ["localhost:9092"],
-  "data_topics": ["fake_events"],
   "histograms": [
     {
       "type": "hist1d",
+      "data_brokers": ["localhost:9092"],
+      "data_topics": ["fake_events"],
       "tof_range": [0, 100000000],
       "num_bins": 50,
       "topic": "output_topic"
@@ -98,13 +98,13 @@ A JSON histogramming configuration has the following parameters:
 
 * "cmd" (string): the command type (config, stop, etc.)
 * "msg_id" (string): a unique identifier for the message
-* "data_brokers" (string array): the addresses of the Kafka brokers
-* "data_topics" (string array): the topics to listen for event data on
 * "start" (seconds since epoch in ms): only histogram data after this UTC time (optional)
 * "stop" (seconds since epoch in ms): only histogram data up to this UTC time (optional)
 * "interval" (seconds): only histogram for this interval (optional)
 * "histograms" (array of dicts): the histograms to create, contains the following:
     * "type" (string): the histogram type (hist1d, hist2d or dethist)
+    * "data_brokers" (string array): the addresses of the Kafka brokers
+    * "data_topics" (string array): the topics to listen for event data on
     * "tof_range" (array of ints): the time-of-flight range to histogram (hist1d and hist2d only)
     * "det_range" (array of ints): the range of detectors to histogram (optional for hist1d)
     * "width" (int): the width of the detector (dethist only)
@@ -118,13 +118,13 @@ For example:
 ```json
 {
   "cmd": "config",
-  "data_brokers": ["localhost:9092"],
-  "data_topics": ["TEST_events"],
   "start": 1564727596867,
   "stop":  1564727668779,
   "histograms": [
     {
       "type": "hist1d",
+      "data_brokers": ["localhost:9092"],
+      "data_topics": ["TEST_events"],
       "tof_range": [0, 100000000],
       "num_bins": 50,
       "topic": "output_topic_for_1d",
@@ -133,6 +133,8 @@ For example:
     },
     {
       "type": "hist2d",
+      "data_brokers": ["localhost:9092"],
+      "data_topics": ["TEST_events"],
       "tof_range": [0, 100000000],
       "det_range": [100, 1000],
       "num_bins": 50,
@@ -142,6 +144,8 @@ For example:
     },
     {
       "type": "dethist",
+      "data_brokers": ["localhost:9092"],
+      "data_topics": ["TEST_events"],
       "tof_range":[0, 100000000],
       "det_range":[1, 6144],
       "width":32,
@@ -244,8 +248,6 @@ For example:
 {
   "cmd": "config",
   "msg_id": "unique_id_123",
-  "data_brokers": ["localhost:9092"],
-  "data_topics": ["TEST_events"],
   ...
 }
 ```

--- a/example_configs/config1d.json
+++ b/example_configs/config1d.json
@@ -1,11 +1,11 @@
 {
     "cmd": "config",
     "msg_id": "some_unique_id",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["fake_events"],
     "histograms": [
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["fake_events"],
             "tof_range": [0, 100000000],
             "num_bins": 50,
             "topic": "hist-topic",

--- a/example_configs/config2d_map.json
+++ b/example_configs/config2d_map.json
@@ -1,11 +1,11 @@
 {
     "cmd": "config",
     "msg_id": "some_unique_id",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["LOQ_events"],
     "histograms": [
         {
             "type": "dethist",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["fake_events"],
             "tof_range": [0, 100000000],
             "det_range": [1, 6144],
             "width": 32,

--- a/example_configs/config2d_tof.json
+++ b/example_configs/config2d_tof.json
@@ -1,11 +1,11 @@
 {
     "cmd": "config",
     "msg_id": "some_unique_id",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["fake_events"],
     "histograms": [
         {
             "type": "hist2d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["fake_events"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,

--- a/just_bin_it/histograms/histogram_factory.py
+++ b/just_bin_it/histograms/histogram_factory.py
@@ -44,16 +44,23 @@ def parse_config(configuration, current_time=None):
     if "histograms" in configuration:
         for hist in configuration["histograms"]:
             # Check for old style syntax
-            if "data_brokers" not in hist or "data_topics" not in hist:
-                if not brokers or not topics:
-                    raise Exception(
-                        "Either the data brokers or data topics were not supplied"
-                    )
-                hist["data_brokers"] = brokers
-                hist["data_topics"] = topics
+            if _is_old_style_config(hist):
+                _handle_old_style_config(brokers, hist, topics)
             hist_configs.append(hist)
 
     return start, stop, hist_configs
+
+
+def _handle_old_style_config(brokers, hist, topics):
+    # Old style configs have the brokers and topics defined at the top-level.
+    if not brokers or not topics:
+        raise Exception("Either the data brokers or data topics were not supplied")
+    hist["data_brokers"] = brokers
+    hist["data_topics"] = topics
+
+
+def _is_old_style_config(hist):
+    return "data_brokers" not in hist or "data_topics" not in hist
 
 
 class HistogramFactory:

--- a/just_bin_it/histograms/histogram_factory.py
+++ b/just_bin_it/histograms/histogram_factory.py
@@ -8,8 +8,17 @@ from just_bin_it.histograms.histogram2d import Histogram2d
 
 
 def parse_config(configuration, current_time=None):
-    brokers = configuration["data_brokers"]
-    topics = configuration["data_topics"]
+    """
+    Parses the configuration that defines the histograms.
+
+    Currently handles both the old-style syntax and the new one (see docs).
+
+    :param configuration: The dictionary containing the configuration.
+    :param current_time: The time to use for defining the start time.
+    :return: tuple of start time, stop time and the list of histograms
+    """
+    brokers = configuration["data_brokers"] if "data_brokers" in configuration else None
+    topics = configuration["data_topics"] if "data_topics" in configuration else None
     start = configuration["start"] if "start" in configuration else None
     stop = configuration["stop"] if "stop" in configuration else None
 
@@ -34,8 +43,14 @@ def parse_config(configuration, current_time=None):
 
     if "histograms" in configuration:
         for hist in configuration["histograms"]:
-            hist["data_brokers"] = brokers
-            hist["data_topics"] = topics
+            # Check for old style syntax
+            if "data_brokers" not in hist or "data_topics" not in hist:
+                if not brokers or not topics:
+                    raise Exception(
+                        "Either the data brokers or data topics were not supplied"
+                    )
+                hist["data_brokers"] = brokers
+                hist["data_topics"] = topics
             hist_configs.append(hist)
 
     return start, stop, hist_configs

--- a/just_bin_it/histograms/histogram_factory.py
+++ b/just_bin_it/histograms/histogram_factory.py
@@ -43,7 +43,6 @@ def parse_config(configuration, current_time=None):
 
     if "histograms" in configuration:
         for hist in configuration["histograms"]:
-            # Check for old style syntax
             if _is_old_style_config(hist):
                 _handle_old_style_config(brokers, hist, topics)
             hist_configs.append(hist)

--- a/system-tests/test_just_bin_it.py
+++ b/system-tests/test_just_bin_it.py
@@ -23,11 +23,11 @@ RESPONSE_TOPIC = "hist_responses"
 
 CONFIG_CMD = {
     "cmd": "config",
-    "data_brokers": BROKERS,
-    "data_topics": ["your topic goes here"],
     "histograms": [
         {
             "type": "hist1d",
+            "data_brokers": BROKERS,
+            "data_topics": ["your topic goes here"],
             "tof_range": TOF_RANGE,
             "det_range": DET_RANGE,
             "num_bins": NUM_BINS,
@@ -85,8 +85,8 @@ class TestJustBinIt:
 
     def create_basic_config(self):
         config = copy.deepcopy(CONFIG_CMD)
-        config["data_topics"] = [self.data_topic_name]
         config["histograms"][0]["topic"] = self.hist_topic_name
+        config["histograms"][0]["data_topics"] = [self.data_topic_name]
         return config
 
     def check_offsets_have_advanced(self):

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -6,13 +6,13 @@ from just_bin_it.histograms.histogram_factory import parse_config
 
 CONFIG_FULL = {
     "cmd": "config",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["junk_data_2"],
     "start": 1571831082207,
     "stop": 1571831125940,
     "histograms": [
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -21,6 +21,8 @@ CONFIG_FULL = {
         },
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -32,12 +34,12 @@ CONFIG_FULL = {
 
 CONFIG_INTERVAL = {
     "cmd": "config",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["junk_data_2"],
     "interval": 5,
     "histograms": [
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -46,6 +48,8 @@ CONFIG_INTERVAL = {
         },
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -57,12 +61,12 @@ CONFIG_INTERVAL = {
 
 CONFIG_NO_DET_RANGE = {
     "cmd": "config",
-    "data_brokers": ["localhost:9092"],
-    "data_topics": ["junk_data_2"],
     "interval": 5,
     "histograms": [
         {
             "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "num_bins": 50,
             "topic": "hist-topic1",
@@ -85,14 +89,28 @@ class TestConfigParser:
         assert stop == CONFIG_FULL["stop"]
 
         for i, h in enumerate(hists):
-            assert h["data_brokers"] == CONFIG_FULL["data_brokers"]
-            assert h["data_topics"] == CONFIG_FULL["data_topics"]
+            assert h["data_brokers"] == CONFIG_FULL["histograms"][i]["data_brokers"]
+            assert h["data_topics"] == CONFIG_FULL["histograms"][i]["data_topics"]
             assert h["type"] == CONFIG_FULL["histograms"][i]["type"]
             assert h["tof_range"] == CONFIG_FULL["histograms"][i]["tof_range"]
             assert h["det_range"] == CONFIG_FULL["histograms"][i]["det_range"]
             assert h["num_bins"] == CONFIG_FULL["histograms"][i]["num_bins"]
             assert h["topic"] == CONFIG_FULL["histograms"][i]["topic"]
             assert h["id"] == CONFIG_FULL["histograms"][i]["id"]
+
+    def test_raises_if_no_data_brokers_supplied_for_a_hist(self):
+        config = copy.deepcopy(CONFIG_FULL)
+        del config["histograms"][0]["data_brokers"]
+
+        with pytest.raises(Exception):
+            parse_config(config)
+
+    def test_raises_if_no_data_topics_supplied_for_a_hist(self):
+        config = copy.deepcopy(CONFIG_FULL)
+        del config["histograms"][0]["data_topics"]
+
+        with pytest.raises(Exception):
+            parse_config(config)
 
     def test_if_no_start_and_stop_then_they_are_not_set(self):
         config = copy.deepcopy(CONFIG_FULL)

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -72,7 +72,7 @@ CONFIG_NO_DET_RANGE = {
 }
 
 
-class TestConfigHandler:
+class TestConfigParser:
     @pytest.fixture(autouse=True)
     def prepare(self):
         pass

--- a/tests/test_config_parsing_old.py
+++ b/tests/test_config_parsing_old.py
@@ -1,18 +1,16 @@
-import copy
-
 import pytest
 
 from just_bin_it.histograms.histogram_factory import parse_config
 
 CONFIG_FULL = {
     "cmd": "config",
+    "data_brokers": ["localhost:9092"],
+    "data_topics": ["junk_data_2"],
     "start": 1571831082207,
     "stop": 1571831125940,
     "histograms": [
         {
             "type": "hist1d",
-            "data_brokers": ["localhost:9092"],
-            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -21,8 +19,6 @@ CONFIG_FULL = {
         },
         {
             "type": "hist1d",
-            "data_brokers": ["localhost:9092"],
-            "data_topics": ["junk_data_2"],
             "tof_range": [0, 100000000],
             "det_range": [0, 100],
             "num_bins": 50,
@@ -33,11 +29,10 @@ CONFIG_FULL = {
 }
 
 
-class TestConfigParserV2:
+class TestConfigParserOldStyle:
     """
-    Tests specific to the new style configuration messages.
-    Eventually can be merged in the original tests when the old-style syntax is
-    retired.
+    Tests specific to the old style configuration messages.
+    Can be deleted when the old-style syntax is retired.
     """
 
     @pytest.fixture(autouse=True)
@@ -52,25 +47,11 @@ class TestConfigParserV2:
         assert stop == CONFIG_FULL["stop"]
 
         for i, h in enumerate(hists):
-            assert h["data_brokers"] == CONFIG_FULL["histograms"][i]["data_brokers"]
-            assert h["data_topics"] == CONFIG_FULL["histograms"][i]["data_topics"]
+            assert h["data_brokers"] == CONFIG_FULL["data_brokers"]
+            assert h["data_topics"] == CONFIG_FULL["data_topics"]
             assert h["type"] == CONFIG_FULL["histograms"][i]["type"]
             assert h["tof_range"] == CONFIG_FULL["histograms"][i]["tof_range"]
             assert h["det_range"] == CONFIG_FULL["histograms"][i]["det_range"]
             assert h["num_bins"] == CONFIG_FULL["histograms"][i]["num_bins"]
             assert h["topic"] == CONFIG_FULL["histograms"][i]["topic"]
             assert h["id"] == CONFIG_FULL["histograms"][i]["id"]
-
-    def test_raises_if_no_data_brokers_supplied_for_a_hist(self):
-        config = copy.deepcopy(CONFIG_FULL)
-        del config["histograms"][0]["data_brokers"]
-
-        with pytest.raises(Exception):
-            parse_config(config)
-
-    def test_raises_if_no_data_topics_supplied_for_a_hist(self):
-        config = copy.deepcopy(CONFIG_FULL)
-        del config["histograms"][0]["data_topics"]
-
-        with pytest.raises(Exception):
-            parse_config(config)

--- a/tests/test_config_parsing_v2.py
+++ b/tests/test_config_parsing_v2.py
@@ -1,0 +1,145 @@
+import copy
+
+import pytest
+
+from just_bin_it.histograms.histogram_factory import parse_config
+
+CONFIG_FULL = {
+    "cmd": "config",
+    "start": 1571831082207,
+    "stop": 1571831125940,
+    "histograms": [
+        {
+            "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
+            "tof_range": [0, 100000000],
+            "det_range": [0, 100],
+            "num_bins": 50,
+            "topic": "hist-topic1",
+            "id": "abcdef",
+        },
+        {
+            "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
+            "tof_range": [0, 100000000],
+            "det_range": [0, 100],
+            "num_bins": 50,
+            "topic": "hist-topic2",
+            "id": "ghijk",
+        },
+    ],
+}
+
+CONFIG_INTERVAL = {
+    "cmd": "config",
+    "interval": 5,
+    "histograms": [
+        {
+            "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
+            "tof_range": [0, 100000000],
+            "det_range": [0, 100],
+            "num_bins": 50,
+            "topic": "hist-topic1",
+            "id": "abcdef",
+        },
+        {
+            "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
+            "tof_range": [0, 100000000],
+            "det_range": [0, 100],
+            "num_bins": 50,
+            "topic": "hist-topic2",
+            "id": "ghijk",
+        },
+    ],
+}
+
+CONFIG_NO_DET_RANGE = {
+    "cmd": "config",
+    "interval": 5,
+    "histograms": [
+        {
+            "type": "hist1d",
+            "data_brokers": ["localhost:9092"],
+            "data_topics": ["junk_data_2"],
+            "tof_range": [0, 100000000],
+            "num_bins": 50,
+            "topic": "hist-topic1",
+            "id": "abcdef",
+        }
+    ],
+}
+
+
+class TestConfigHandler:
+    @pytest.fixture(autouse=True)
+    def prepare(self):
+        pass
+
+    def test_if_histograms_then_all_config_settings_added_correctly(self):
+        start, stop, hists = parse_config(CONFIG_FULL)
+
+        assert len(hists) == 2
+        assert start == CONFIG_FULL["start"]
+        assert stop == CONFIG_FULL["stop"]
+
+        for i, h in enumerate(hists):
+            assert h["data_brokers"] == CONFIG_FULL["data_brokers"]
+            assert h["data_topics"] == CONFIG_FULL["data_topics"]
+            assert h["type"] == CONFIG_FULL["histograms"][i]["type"]
+            assert h["tof_range"] == CONFIG_FULL["histograms"][i]["tof_range"]
+            assert h["det_range"] == CONFIG_FULL["histograms"][i]["det_range"]
+            assert h["num_bins"] == CONFIG_FULL["histograms"][i]["num_bins"]
+            assert h["topic"] == CONFIG_FULL["histograms"][i]["topic"]
+            assert h["id"] == CONFIG_FULL["histograms"][i]["id"]
+
+    def test_if_no_start_and_stop_then_they_are_not_set(self):
+        config = copy.deepcopy(CONFIG_FULL)
+        del config["start"]
+        del config["stop"]
+
+        start, stop, _ = parse_config(config)
+
+        assert start is None
+        assert stop is None
+
+    def test_if_interval_defined_then_start_and_stop_are_initialised(self):
+        current_time = 123456
+        start, stop, _ = parse_config(CONFIG_INTERVAL, current_time)
+
+        assert start == current_time
+        assert stop == current_time + CONFIG_INTERVAL["interval"] * 1000
+
+    def test_if_interval_negative_then_parsing_throws(self):
+        config = copy.deepcopy(CONFIG_INTERVAL)
+        config["interval"] = -5
+
+        with pytest.raises(Exception):
+            parse_config(config)
+
+    def test_if_interval_and_start_defined_then_parsing_throws(self):
+        config = copy.deepcopy(CONFIG_INTERVAL)
+        config["start"] = 1 * 10 ** 9
+
+        with pytest.raises(Exception):
+            parse_config(config)
+
+    def test_if_interval_and_stop_defined_then_parsing_throws(self):
+        config = copy.deepcopy(CONFIG_INTERVAL)
+        config["stop"] = 1 * 10 ** 9
+
+        with pytest.raises(Exception):
+            parse_config(config)
+
+    def test_if_does_not_contains_histogram_then_none_found(self):
+        config = copy.deepcopy(CONFIG_FULL)
+        del config["histograms"]
+
+        _, _, hists = parse_config(config)
+
+        assert len(hists) == 0


### PR DESCRIPTION
Adds the new syntax which allows per histogram brokers and topics.

Still works with the old-style command for now