### PR TITLE
Pin version of python-streaming-data-types

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 confluent-kafka
-ess-streaming-data-types
+ess-streaming-data-types==0.9.1
 fast-histogram
 graphyte
 kafka-python


### PR DESCRIPTION
Need to be aware of the version in case of breaking changes.
Added dependabot to make this obvious.