### PR TITLE
Docker option "--no-log-prefix" needs to be included

### DIFF
--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -27,6 +27,7 @@ common_options = {
     "--tail": "all",
     "--detach": True,
     "--build": False,
+    "--no-log-prefix": False,
 }
 
 WAIT_FOR_DEBUGGER_ATTACH = "--wait-to-attach-debugger"


### PR DESCRIPTION
Otherwise, system tests cannot run