### PR TITLE
ECDC-2298: can have different bins for x and y

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ A JSON histogramming configuration has the following parameters:
     * "det_range" (array of ints): the range of detectors to histogram (optional for hist1d)
     * "width" (int): the width of the detector (dethist only)
     * "height" (int): the height of the detector (dethist only)
-    * "num_bins" (int): the number of histogram bins (hist1d and hist2d only)
+    * "num_bins" int or array_like or [int, int]
+    	* if int, the number of bins for the two dimensions (nx=ny=bins) 
+  		* if array_like, the number of bins for the two dimensions  
     * "topic" (string): the topic to write histogram data to
     * "source" (string): the name of the source to accept data from
     * "id" (string): a unique identifier for the histogram which will be contained in the published histogram data (optional but recommended)
@@ -137,7 +139,7 @@ For example:
       "data_topics": ["TEST_events"],
       "tof_range": [0, 100000000],
       "det_range": [100, 1000],
-      "num_bins": 50,
+      "num_bins": 50, # can also be written as [50, 50]
       "topic": "output_topic_for_2d",
       "source": "detector1",
       "id": "histogram2d"

--- a/README.md
+++ b/README.md
@@ -109,9 +109,7 @@ A JSON histogramming configuration has the following parameters:
     * "det_range" (array of ints): the range of detectors to histogram (optional for hist1d)
     * "width" (int): the width of the detector (dethist only)
     * "height" (int): the height of the detector (dethist only)
-    * "num_bins": 
-      - (int) for hist1d
-      - array_like [int, int] for hist2d
+    * "num_bins" (int for 1D or [int, int] for 2D): the number of histogram bins (hist1d and hist2d only)
     * "topic" (string): the topic to write histogram data to
     * "source" (string): the name of the source to accept data from
     * "id" (string): a unique identifier for the histogram which will be contained in the published histogram data (optional but recommended)

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ A JSON histogramming configuration has the following parameters:
     * "det_range" (array of ints): the range of detectors to histogram (optional for hist1d)
     * "width" (int): the width of the detector (dethist only)
     * "height" (int): the height of the detector (dethist only)
-    * "num_bins" int or array_like or [int, int]
-    	* if int, the number of bins for the two dimensions (nx=ny=bins) 
-  		* if array_like, the number of bins for the two dimensions  
+    * "num_bins": 
+      - (int) for hist1d
+      - array_like [int, int] for hist2d
     * "topic" (string): the topic to write histogram data to
     * "source" (string): the name of the source to accept data from
     * "id" (string): a unique identifier for the histogram which will be contained in the published histogram data (optional but recommended)
@@ -139,7 +139,7 @@ For example:
       "data_topics": ["TEST_events"],
       "tof_range": [0, 100000000],
       "det_range": [100, 1000],
-      "num_bins": 50, # can also be written as [50, 50]
+      "num_bins": [50, 50],
       "topic": "output_topic_for_2d",
       "source": "detector1",
       "id": "histogram2d"

--- a/just_bin_it/histograms/histogram1d.py
+++ b/just_bin_it/histograms/histogram1d.py
@@ -65,9 +65,9 @@ class Histogram1d:
         self.identifier = identifier
         self.source = source if source.strip() != "" else None
 
-        self._intialise_histogram()
+        self._initialise_histogram()
 
-    def _intialise_histogram(self):
+    def _initialise_histogram(self):
         """
         Create a zeroed histogram with the correct shape.
         """
@@ -118,4 +118,4 @@ class Histogram1d:
         Clears the histogram data, but maintains the other values (e.g. edges etc.)
         """
         logging.info("Clearing data")  # pragma: no mutate
-        self._intialise_histogram()
+        self._initialise_histogram()

--- a/just_bin_it/histograms/histogram2d.py
+++ b/just_bin_it/histograms/histogram2d.py
@@ -56,9 +56,9 @@ class Histogram2d:
         self.identifier = identifier
         self.source = source if source.strip() != "" else None
 
-        self._intialise_histogram()
+        self._initialise_histogram()
 
-    def _intialise_histogram(self):
+    def _initialise_histogram(self):
         """
         Create a zeroed histogram with the correct shape.
         """
@@ -98,4 +98,4 @@ class Histogram2d:
         Clears the histogram data, but maintains the other values (e.g. edges etc.)
         """
         logging.info("Clearing data")  # pragma: no mutate
-        self._intialise_histogram()
+        self._initialise_histogram()

--- a/just_bin_it/histograms/input_validators.py
+++ b/just_bin_it/histograms/input_validators.py
@@ -16,15 +16,18 @@ def check_bins(num_bins, missing, invalid):
     if num_bins is None:
         missing.append("number of bins")  # pragma: no mutate
         return
-    
+
     if isinstance(num_bins, int):
         if num_bins < 1:
             invalid.append("Number of bins")
+            return
+        check_int(num_bins, "number of bins", invalid)
     elif isinstance(num_bins, (list, tuple)):
         if len(num_bins) != 2:
             invalid.append("Dimension of number of bins")
-        elif num_bins[0] < 1 or num_bins[1] < 1:
-            invalid.append("Range of number of bins")
+            return
+        check_int(num_bins[0], "y", invalid)
+        check_int(num_bins[1], "x", invalid)
     else:
         invalid.append("Unknown type of num_bins")
 

--- a/just_bin_it/histograms/input_validators.py
+++ b/just_bin_it/histograms/input_validators.py
@@ -20,12 +20,13 @@ def check_bins(num_bins, missing, invalid):
     if isinstance(num_bins, int):
         if num_bins < 1:
             invalid.append("Number of bins")
-
     elif isinstance(num_bins, (list, tuple)):
         if len(num_bins) != 2:
             invalid.append("Dimension of number of bins")
         elif num_bins[0] < 1 or num_bins[1] < 1:
             invalid.append("Range of number of bins")
+    else:
+        invalid.append("Unknown type of num_bins")
 
 
 def check_int(value, field, invalid):

--- a/just_bin_it/histograms/input_validators.py
+++ b/just_bin_it/histograms/input_validators.py
@@ -26,8 +26,8 @@ def check_bins(num_bins, missing, invalid):
         if len(num_bins) != 2:
             invalid.append("Dimension of number of bins")
             return
-        check_int(num_bins[0], "y", invalid)
-        check_int(num_bins[1], "x", invalid)
+        check_int(num_bins[0], "x", invalid)
+        check_int(num_bins[1], "y", invalid)
     else:
         invalid.append("Unknown type of num_bins")
 

--- a/just_bin_it/histograms/input_validators.py
+++ b/just_bin_it/histograms/input_validators.py
@@ -16,7 +16,16 @@ def check_bins(num_bins, missing, invalid):
     if num_bins is None:
         missing.append("number of bins")  # pragma: no mutate
         return
-    check_int(num_bins, "number of bins", invalid)
+    
+    if isinstance(num_bins, int):
+        if num_bins < 1:
+            invalid.append("Number of bins")
+
+    elif isinstance(num_bins, (list, tuple)):
+        if len(num_bins) != 2:
+            invalid.append("Dimension of number of bins")
+        elif num_bins[0] < 1 or num_bins[1] < 1:
+            invalid.append("Range of number of bins")
 
 
 def check_int(value, field, invalid):

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -8,8 +8,6 @@ IRRELEVANT_TOPIC = "some-topic"
 IRRELEVANT_NUM_BINS = 123
 IRRELEVANT_TOF_RANGE = (0, 100)
 IRRELEVANT_DET_RANGE = (0, 100)
-ILLEGAL_NUM_BINS_DIMS = [5, 10, 15]
-ILLEGAL_NUM_BINS_VALUES = [0, 10]
 
 
 class TestHistogram2dFunctionality:
@@ -152,12 +150,12 @@ class TestHistogram2dConstruction:
 
     def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
         with pytest.raises(JustBinItException):
-            Histogram2d(IRRELEVANT_TOPIC, ILLEGAL_NUM_BINS_DIMS, 
+            Histogram2d(IRRELEVANT_TOPIC, [5, 10, 15], 
                         IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
 
     def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
         with pytest.raises(JustBinItException):
-            Histogram2d(IRRELEVANT_TOPIC, ILLEGAL_NUM_BINS_VALUES, 
+            Histogram2d(IRRELEVANT_TOPIC, [0, 10], 
                         IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
 
     def test_if_no_id_specified_then_empty_string(self):

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -152,7 +152,7 @@ class TestHistogram2dConstruction:
                 IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, IRRELEVANT_TOF_RANGE, (1,)
             )
 
-    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_number_of_dimensions(self):
+    def test_throws_if_number_of_bin_dimensions_exceeds_two(self):
         with pytest.raises(JustBinItException):
             Histogram2d(
                 IRRELEVANT_TOPIC,

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -5,7 +5,7 @@ from just_bin_it.exceptions import JustBinItException
 from just_bin_it.histograms.histogram2d import Histogram2d
 
 IRRELEVANT_TOPIC = "some-topic"
-IRRELEVANT_NUM_BINS = 123
+IRRELEVANT_NUM_BINS = (123, 456)
 IRRELEVANT_TOF_RANGE = (0, 100)
 IRRELEVANT_DET_RANGE = (0, 100)
 
@@ -14,29 +14,25 @@ class TestHistogram2dFunctionality:
     @pytest.fixture(autouse=True)
     def prepare(self):
         self.pulse_time = 1234
-        self.num_bins = 5
+        self.num_bins = (5, 10)
         self.tof_range = (0, 10)
         self.det_range = (0, 5)
-        self.data = np.array([x for x in range(self.num_bins)])
+        self.data = np.array([x for x in range(self.num_bins[0])])
         self.hist = Histogram2d("topic", self.num_bins, self.tof_range, self.det_range)
 
-    def test_different_number_of_bins_for_x_and_y(self):
-        num_bins_xy = [5, 10]
-        hist = Histogram2d("topic", num_bins_xy, self.tof_range, self.det_range)
-        assert len(hist.x_edges) == num_bins_xy[0] + 1
-        assert len(hist.y_edges) == num_bins_xy[1] + 1
-        assert hist.shape == tuple(num_bins_xy)
-
-        # add data and check the shape of histogram
-        hist.add_data(self.pulse_time, self.data, self.data)
-        assert hist.data.shape == tuple(num_bins_xy)
+    def test_if_single_value_for_num_bins_then_value_used_for_both_x_and_y(self):
+        num_bins = 5
+        hist = Histogram2d("topic", num_bins, self.tof_range, self.det_range)
+        assert len(hist.x_edges) == num_bins + 1
+        assert len(hist.y_edges) == num_bins + 1
+        assert hist.shape == (num_bins, num_bins)
 
     def test_on_construction_histogram_is_uninitialised(self):
         assert self.hist.x_edges is not None
         assert self.hist.y_edges is not None
-        assert self.hist.shape == (self.num_bins, self.num_bins)
-        assert len(self.hist.x_edges) == self.num_bins + 1
-        assert len(self.hist.y_edges) == self.num_bins + 1
+        assert self.hist.shape == self.num_bins
+        assert len(self.hist.x_edges) == self.num_bins[0] + 1
+        assert len(self.hist.y_edges) == self.num_bins[1] + 1
         assert self.hist.x_edges[0] == self.data[0]
         assert self.hist.x_edges[-1] == 10
         assert self.hist.y_edges[0] == self.data[0]
@@ -60,7 +56,7 @@ class TestHistogram2dFunctionality:
         y_edges = self.hist.y_edges[:]
 
         # Add data that is outside the edges
-        new_data = np.array([x + self.num_bins + 1 for x in range(self.num_bins)])
+        new_data = np.array([x + self.num_bins[0] + 1 for x in range(self.num_bins[0])])
         self.hist.add_data(self.pulse_time, new_data, new_data)
 
         # Sum should not change
@@ -107,7 +103,7 @@ class TestHistogram2dFunctionality:
 
         self.hist.add_data(self.pulse_time, self.data, self.data)
 
-        assert self.hist.shape == (self.num_bins, self.num_bins)
+        assert self.hist.shape == self.num_bins
         assert self.hist.data.sum() == 5
 
     def test_adding_empty_data_does_nothing(self):
@@ -139,12 +135,26 @@ class TestHistogram2dConstruction:
     def test_if_bins_not_numeric_then_histogram_not_created(self):
         with pytest.raises(JustBinItException):
             Histogram2d(
-                IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, None, IRRELEVANT_DET_RANGE
+                IRRELEVANT_TOPIC, ("a", "b"), IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
             )
 
-    def test_if_bins_not_greater_than_zero_then_histogram_not_created(self):
+    def test_if_bins_less_than_one_then_histogram_not_created(self):
         with pytest.raises(JustBinItException):
-            Histogram2d(IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, 0, IRRELEVANT_DET_RANGE)
+            Histogram2d(
+                IRRELEVANT_TOPIC, (0, 10), IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+            )
+        with pytest.raises(JustBinItException):
+            Histogram2d(
+                IRRELEVANT_TOPIC, (10, 0), IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+            )
+        with pytest.raises(JustBinItException):
+            Histogram2d(
+                IRRELEVANT_TOPIC, (-10, 10), IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+            )
+        with pytest.raises(JustBinItException):
+            Histogram2d(
+                IRRELEVANT_TOPIC, (10, -10), IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+            )
 
     def test_if_det_range_is_not_two_values_then_histogram_not_created(self):
         with pytest.raises(JustBinItException):
@@ -152,7 +162,7 @@ class TestHistogram2dConstruction:
                 IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, IRRELEVANT_TOF_RANGE, (1,)
             )
 
-    def test_throws_if_number_of_bin_dimensions_exceeds_two(self):
+    def test_if_number_of_bin_dimensions_exceeds_two_then_histogram_not_created(self):
         with pytest.raises(JustBinItException):
             Histogram2d(
                 IRRELEVANT_TOPIC,
@@ -161,10 +171,12 @@ class TestHistogram2dConstruction:
                 IRRELEVANT_DET_RANGE,
             )
 
-    def test_throws_if_bin_value_is_less_than_one(self):
+    def test_one_bin_number_and_less_than_one_then_histogram_not_created(self):
+        with pytest.raises(JustBinItException):
+            Histogram2d(IRRELEVANT_TOPIC, 0, IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
         with pytest.raises(JustBinItException):
             Histogram2d(
-                IRRELEVANT_TOPIC, [0, 10], IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+                IRRELEVANT_TOPIC, -10, IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
             )
 
     def test_if_no_id_specified_then_empty_string(self):

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -161,7 +161,7 @@ class TestHistogram2dConstruction:
                 IRRELEVANT_DET_RANGE,
             )
 
-    def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
+    def test_throws_if_bin_value_is_less_than_one(self):
         with pytest.raises(JustBinItException):
             Histogram2d(
                 IRRELEVANT_TOPIC, [0, 10], IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -20,6 +20,29 @@ class TestHistogram2dFunctionality:
         self.data = np.array([x for x in range(self.num_bins)])
         self.hist = Histogram2d("topic", self.num_bins, self.tof_range, self.det_range)
 
+
+    def test_different_number_of_bins_for_x_and_y_works(self):
+        num_bins_xy = [5, 10]
+        hist_xy = Histogram2d("topic", num_bins_xy, self.tof_range,
+                              self.det_range)
+        assert len(hist_xy.x_edges) == num_bins_xy[0] + 1
+        assert len(hist_xy.y_edges) == num_bins_xy[1] + 1
+
+
+    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
+        with pytest.raises(JustBinItException):
+            Histogram2d("topic", [5, 10, 15], self.tof_range,
+                        self.det_range)
+        with pytest.raises(JustBinItException):
+            Histogram2d("topic", (5, 10, 15), self.tof_range,
+                        self.det_range)
+
+    def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
+        with pytest.raises(JustBinItException):
+            Histogram2d("topic", [0, 10], self.tof_range,
+                        self.det_range)
+
+
     def test_on_construction_histogram_is_uninitialised(self):
         assert self.hist.x_edges is not None
         assert self.hist.y_edges is not None

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -22,10 +22,14 @@ class TestHistogram2dFunctionality:
 
     def test_different_number_of_bins_for_x_and_y_works(self):
         num_bins_xy = [5, 10]
-        hist_xy = Histogram2d("topic", num_bins_xy, self.tof_range,
-                              self.det_range)
-        assert len(hist_xy.x_edges) == num_bins_xy[0] + 1
-        assert len(hist_xy.y_edges) == num_bins_xy[1] + 1
+        hist = Histogram2d("topic", num_bins_xy, self.tof_range, self.det_range)
+        assert len(hist.x_edges) == num_bins_xy[0] + 1
+        assert len(hist.y_edges) == num_bins_xy[1] + 1
+        assert hist.shape == tuple(num_bins_xy)
+
+        # add data and check the shape of histogram
+        hist.add_data(self.pulse_time, self.data, self.data)
+        assert hist.data.shape == tuple(num_bins_xy)
 
     def test_on_construction_histogram_is_uninitialised(self):
         assert self.hist.x_edges is not None
@@ -150,13 +154,18 @@ class TestHistogram2dConstruction:
 
     def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
         with pytest.raises(JustBinItException):
-            Histogram2d(IRRELEVANT_TOPIC, [5, 10, 15], 
-                        IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
+            Histogram2d(
+                IRRELEVANT_TOPIC,
+                [5, 10, 15],
+                IRRELEVANT_TOF_RANGE,
+                IRRELEVANT_DET_RANGE,
+            )
 
     def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
         with pytest.raises(JustBinItException):
-            Histogram2d(IRRELEVANT_TOPIC, [0, 10], 
-                        IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
+            Histogram2d(
+                IRRELEVANT_TOPIC, [0, 10], IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE
+            )
 
     def test_if_no_id_specified_then_empty_string(self):
         histogram = Histogram2d(

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -152,7 +152,7 @@ class TestHistogram2dConstruction:
                 IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, IRRELEVANT_TOF_RANGE, (1,)
             )
 
-    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
+    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_number_of_dimensions(self):
         with pytest.raises(JustBinItException):
             Histogram2d(
                 IRRELEVANT_TOPIC,

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -20,7 +20,7 @@ class TestHistogram2dFunctionality:
         self.data = np.array([x for x in range(self.num_bins)])
         self.hist = Histogram2d("topic", self.num_bins, self.tof_range, self.det_range)
 
-    def test_different_number_of_bins_for_x_and_y_works(self):
+    def test_different_number_of_bins_for_x_and_y(self):
         num_bins_xy = [5, 10]
         hist = Histogram2d("topic", num_bins_xy, self.tof_range, self.det_range)
         assert len(hist.x_edges) == num_bins_xy[0] + 1

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -8,6 +8,8 @@ IRRELEVANT_TOPIC = "some-topic"
 IRRELEVANT_NUM_BINS = 123
 IRRELEVANT_TOF_RANGE = (0, 100)
 IRRELEVANT_DET_RANGE = (0, 100)
+ILLEGAL_NUM_BINS_DIMS = [5, 10, 15]
+ILLEGAL_NUM_BINS_VALUES = [0, 10]
 
 
 class TestHistogram2dFunctionality:
@@ -20,28 +22,12 @@ class TestHistogram2dFunctionality:
         self.data = np.array([x for x in range(self.num_bins)])
         self.hist = Histogram2d("topic", self.num_bins, self.tof_range, self.det_range)
 
-
     def test_different_number_of_bins_for_x_and_y_works(self):
         num_bins_xy = [5, 10]
         hist_xy = Histogram2d("topic", num_bins_xy, self.tof_range,
                               self.det_range)
         assert len(hist_xy.x_edges) == num_bins_xy[0] + 1
         assert len(hist_xy.y_edges) == num_bins_xy[1] + 1
-
-
-    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
-        with pytest.raises(JustBinItException):
-            Histogram2d("topic", [5, 10, 15], self.tof_range,
-                        self.det_range)
-        with pytest.raises(JustBinItException):
-            Histogram2d("topic", (5, 10, 15), self.tof_range,
-                        self.det_range)
-
-    def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
-        with pytest.raises(JustBinItException):
-            Histogram2d("topic", [0, 10], self.tof_range,
-                        self.det_range)
-
 
     def test_on_construction_histogram_is_uninitialised(self):
         assert self.hist.x_edges is not None
@@ -163,6 +149,16 @@ class TestHistogram2dConstruction:
             Histogram2d(
                 IRRELEVANT_TOPIC, IRRELEVANT_NUM_BINS, IRRELEVANT_TOF_RANGE, (1,)
             )
+
+    def test_different_number_of_bins_for_x_and_y_fails_if_wrong_dim(self):
+        with pytest.raises(JustBinItException):
+            Histogram2d(IRRELEVANT_TOPIC, ILLEGAL_NUM_BINS_DIMS, 
+                        IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
+
+    def test_different_number_of_bins_for_x_and_y_fails_with_negative_values(self):
+        with pytest.raises(JustBinItException):
+            Histogram2d(IRRELEVANT_TOPIC, ILLEGAL_NUM_BINS_VALUES, 
+                        IRRELEVANT_TOF_RANGE, IRRELEVANT_DET_RANGE)
 
     def test_if_no_id_specified_then_empty_string(self):
         histogram = Histogram2d(


### PR DESCRIPTION
Allow `Histogram2d` to accept different `bins` for `x` and `y` dimensions. 