### PR TITLE
Change heartbeat messages to flatbuffers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,15 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
+-   repo: https://github.com/psf/black
+    rev: 21.9b0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 -   repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
     - id: flake8
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.2.1
+-   repo: https://github.com/pycqa/isort
+    rev: 5.9.3
     hooks:
     - id: isort
+      args: ["--profile", "black"]

--- a/just_bin_it/endpoints/heartbeat_publisher.py
+++ b/just_bin_it/endpoints/heartbeat_publisher.py
@@ -1,5 +1,8 @@
-import json
 import logging
+from os import getpid
+from socket import gethostname
+
+from streaming_data_types import serialise_x5f2
 
 from just_bin_it.exceptions import KafkaException
 
@@ -10,6 +13,8 @@ class HeartbeatPublisher:
         self.topic = topic
         self.heartbeat_interval_ms = heartbeat_interval_ms
         self.next_time_to_publish = 0
+        self._host = gethostname()
+        self._pid = getpid()
 
     def publish(self, current_time_ms):
         """
@@ -30,12 +35,17 @@ class HeartbeatPublisher:
             self.next_time_to_publish % self.heartbeat_interval_ms
         )
 
-    def _publish(self, current_time_ms):
-        msg = {
-            "message": current_time_ms,
-            "message_interval": self.heartbeat_interval_ms,
-        }
+    def _publish(self, current_time_ms=0):
         try:
-            self.producer.publish_message(self.topic, bytes(json.dumps(msg), "utf-8"))
+            msg = serialise_x5f2(
+                "just-bin-it",
+                "",
+                "",
+                self._host,
+                self._pid,
+                self.heartbeat_interval_ms,
+                "",
+            )
+            self.producer.publish_message(self.topic, msg)
         except KafkaException as error:
             logging.error("Could not publish heartbeat: %s", error)

--- a/just_bin_it/endpoints/heartbeat_publisher.py
+++ b/just_bin_it/endpoints/heartbeat_publisher.py
@@ -25,7 +25,7 @@ class HeartbeatPublisher:
         assert current_time_ms >= 0
 
         if current_time_ms >= self.next_time_to_publish:
-            self._publish(current_time_ms)
+            self._publish()
             self._update_publish_time(current_time_ms)
 
     def _update_publish_time(self, current_time_ms):
@@ -35,7 +35,7 @@ class HeartbeatPublisher:
             self.next_time_to_publish % self.heartbeat_interval_ms
         )
 
-    def _publish(self, current_time_ms=0):
+    def _publish(self):
         try:
             msg = serialise_x5f2(
                 "just-bin-it",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
-black
-flake8
-isort
+black==21.9b0   # Pinned to match pre-commit config
+flake8==3.8.3   # Pinned to match pre-commit config
+isort==5.9.3    # Pinned to match pre-commit config
 mutmut
 pre-commit
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ flake8
 isort
 mutmut
 pre-commit
+pytest
 pytest-cov
 tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 black
 flake8
+isort
 mutmut
 pre-commit
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ graphyte
 kafka-python
 mock
 numpy
-pytest

--- a/tests/test_config_listener.py
+++ b/tests/test_config_listener.py
@@ -19,7 +19,7 @@ class TestConfigListener:
         assert self.config_listener.check_for_messages()
 
     def test_when_waiting_message_not_consumed_checking_again_still_returns_message_waiting(
-        self
+        self,
     ):
         self.consumer.add_messages([(0, 0, '"message1"')])
         self.config_listener.check_for_messages()

--- a/tests/test_event_source.py
+++ b/tests/test_event_source.py
@@ -252,7 +252,7 @@ class TestEventSourceMultiplePartitions:
         assert compare_two_messages(self.messages[45], new_data[0])
 
     def test_given_time_more_recent_than_last_message_then_seeks_to_last_message_on_all_partitions(
-        self
+        self,
     ):
         last_timestamp, _, _ = self.messages[149]
         msg_time = last_timestamp + 1000
@@ -262,7 +262,7 @@ class TestEventSourceMultiplePartitions:
         assert offsets == [50, 50, 50]
 
     def test_query_for_exact_last_message_time_finds_correct_offset_for_all_partitions(
-        self
+        self,
     ):
         expected_timestamp, _, _ = self.messages[149]
         self.event_source.start_time = expected_timestamp
@@ -271,7 +271,7 @@ class TestEventSourceMultiplePartitions:
         assert offsets == [50, 50, 49]
 
     def test_query_for_inaccurate_last_message_time_finds_next_offset_for_all_partitions(
-        self
+        self,
     ):
         expected_timestamp, _, _ = self.messages[149]
         # Go back a little, so it should find the expected message

--- a/tests/test_heartbeat_publisher.py
+++ b/tests/test_heartbeat_publisher.py
@@ -1,6 +1,8 @@
-import json
+from os import getpid
+from socket import gethostname
 
 import pytest
+from streaming_data_types import deserialise_x5f2
 
 from just_bin_it.endpoints.heartbeat_publisher import HeartbeatPublisher
 from just_bin_it.utilities import time_in_ns
@@ -43,9 +45,14 @@ class TestHeartbeatPublisher:
         self.publisher.publish(current_time_ms)
 
         _, msg = self.producer.messages[0]
-        msg = json.loads(msg)
-        assert msg["message"] == current_time_ms
-        assert msg["message_interval"] == self.update_interval
+        msg = deserialise_x5f2(msg)
+        assert msg.software_name == "just-bin-it"
+        assert msg.host_name == gethostname()
+        assert msg.process_id == getpid()
+        assert msg.update_interval == self.update_interval
+        assert msg.service_id == ""
+        assert msg.software_version == ""
+        assert msg.status_json == ""
 
     def test_after_first_message_publish_if_interval_has_passed(self):
         current_time_ms = time_in_ns() // 1_000_000

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py36, py37, py38
+envlist = py36, py37, py38, py39
 requires = tox-conda
 isolated_build = true
 skipsdist=true
 
 [testenv]
 deps =
-    -r{toxinidir}/requirements.txt
+    pytest
+    -Ur{toxinidir}/requirements.txt
 commands =
     python -m pytest {posargs}
 


### PR DESCRIPTION
Rather than use JSON we should use the appropriate flatbuffer schema.

Unfortunately this PR required updating some pre-commit stuff, so there is more stuff than expected.