### PR TITLE
fix docker version

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,3 +1,3 @@
 docker-compose>=1.20.0
-docker>=3.4.1
+docker==6.1.3
 pytest-rerunfailures


### PR DESCRIPTION
docker 7 breaks docker-compose v1 compatibility.
See https://github.com/docker/docker-py/issues/3194

We will need to fix this properly but does pining the version give us some breathing room?